### PR TITLE
Struct serialisation

### DIFF
--- a/src/nizk.rs
+++ b/src/nizk.rs
@@ -35,7 +35,7 @@ use sha2::Sha512;
 /// where \\(A\_i = g^{a_i}\\), and using it to compute
 /// \\(s'\_i = \mathcal{H}(i, \phi, A\_i, M'\_i)\\), then finally
 /// \\(s\_i \stackrel{?}{=} s'\_i\\).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NizkOfSecretKey {
     /// The scalar portion of the Schnorr signature encoding the context.
     s: Scalar,

--- a/src/precomputation.rs
+++ b/src/precomputation.rs
@@ -132,7 +132,7 @@ pub struct SecretCommitmentShareList {
 ///
 /// This should be published somewhere before the signing protocol takes place
 /// for the other signing participants to obtain.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PublicCommitmentShareList {
     /// The participant's index.
     pub participant_index: u32,


### PR DESCRIPTION
Add `to_bytes()` and `from_bytes()` to structs used in KeyGen and Sign phases

closes #16 