### PR TITLE
Change AES mode of operation to CTR in share encryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 hashbrown = { version = "0.11", default-features = false, features = ["ahash", "inline-more"] }
-aes = { version = "0.7", default-features = false }
+aes = { version = "0.7", default-features = false, features = ["ctr"] }
 hkdf = { version = "0.11", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
The default implementation relies on ECB which isn't safe (see [here](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Electronic_codebook_(ECB)) for more info).
Switches to counter mode with a nonce of 128bits randomly sampled (relies on OsRng internally during encrypt_share() to match other methods in KeyGen, would probably be better to have rng passed as parameter, as suggested in #13, which can be done later on).