### PR TITLE
DKG state serialisation

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -9,6 +9,9 @@
 
 //! Configurable parameters for an instance of a FROST signing protocol.
 
+use core::convert::TryInto;
+use crate::keygen::Error;
+
 /// The configuration parameters for conducting the process of creating a
 /// threshold signature.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
@@ -17,4 +20,31 @@ pub struct Parameters {
     pub n: u32,
     /// The threshold required for a successful signature.
     pub t: u32,
+}
+
+impl Parameters {
+    /// Serialise these parameters as an array of bytes
+    pub fn to_bytes(&self) -> [u8; 8] {
+        let mut res = [0u8; 8];
+        res[0..4].copy_from_slice(&self.n.to_le_bytes());
+        res[4..8].copy_from_slice(&self.t.to_le_bytes());
+
+        res
+    }
+
+    /// Deserialise this slice of bytes to `Parameters`
+    pub fn from_bytes(bytes: &[u8]) -> Result<Parameters, Error> {
+        let n = u32::from_le_bytes(
+            bytes[0..4]
+                .try_into()
+                .map_err(|_| Error::SerialisationError)?,
+        );
+        let t = u32::from_le_bytes(
+            bytes[4..8]
+                .try_into()
+                .map_err(|_| Error::SerialisationError)?,
+        );
+
+        Ok(Parameters { n, t })
+    }
 }


### PR DESCRIPTION
Attempt to have a serialisable DKG state for both rounds.
Wrapped dh_public_keys `RistrettoPoint` similarly to what was previously done for dh_private_keys.