### PR TITLE
Integrate Static FROST

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # ICE-FROST
 
-A fork of the Rust implementation of [FROST: Flexible Round-Optimised Schnorr Threshold signatures](https://eprint.iacr.org/2020/852) by Chelsea Komlo and Ian Goldberg, originally developed at https://github.com/isislovecruft/frost-dalek and adapted to support additional Identifiable Cheating Entity property. This new protocol is named [ICE-FROST](https://eprint.iacr.org/2021/1658).
+A fork of the Rust implementation of [FROST: Flexible Round-Optimised Schnorr Threshold signatures](https://eprint.iacr.org/2020/852) by Chelsea Komlo and Ian Goldberg, originally developed at https://github.com/isislovecruft/frost-dalek and adapted to support additional Identifiable Cheating Entity property and Static group keys. This new protocol is named [ICE-FROST](https://eprint.iacr.org/2021/1658).
 
 ## Usage
 

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -59,7 +59,7 @@ mod dkg_benches {
         }
 
         c.bench_function("Round One", move |b| {
-            b.iter(|| DistributedKeyGeneration::<_>::new_initial_state(&params,
+            b.iter(|| DistributedKeyGeneration::<_>::new_initial(&params,
                                                          &p1_dh_sk,
                                                          &p1.index,
                                                          &coefficient,
@@ -84,7 +84,7 @@ mod dkg_benches {
 
         let mut p1_my_encrypted_secret_shares = Vec::<EncryptedSecretShare>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
-        let p1_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+        let p1_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                           &dh_secret_keys[0],
                                                           &participants[0].index.clone(),
                                                           &coefficients[0],
@@ -94,7 +94,7 @@ mod dkg_benches {
         p1_my_encrypted_secret_shares.push(p1_their_encrypted_secret_shares[0].clone());
 
         for i in 2..NUMBER_OF_PARTICIPANTS+1 {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[(i-1) as usize],
                                                               &participants[(i-1) as usize].index.clone(),
                                                               &coefficients[(i-1) as usize],
@@ -125,7 +125,7 @@ mod dkg_benches {
 
         let mut p1_my_encrypted_secret_shares = Vec::<EncryptedSecretShare>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
-        let p1_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+        let p1_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                           &dh_secret_keys[0],
                                                           &participants[0].index.clone(),
                                                           &coefficients[0],
@@ -135,7 +135,7 @@ mod dkg_benches {
         p1_my_encrypted_secret_shares.push(p1_their_encrypted_secret_shares[0].clone());
 
         for i in 2..NUMBER_OF_PARTICIPANTS+1 {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[(i-1) as usize],
                                                               &participants[(i-1) as usize].index.clone(),
                                                               &coefficients[(i-1) as usize],
@@ -187,7 +187,7 @@ mod sign_benches {
         let mut participants_states_2 = Vec::<DistributedKeyGeneration::<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
         for i in 0..NUMBER_OF_PARTICIPANTS {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[i as usize],
                                                               &participants[i as usize].index.clone(),
                                                               &coefficients[i as usize],
@@ -272,7 +272,7 @@ mod sign_benches {
         let mut participants_states_2 = Vec::<DistributedKeyGeneration::<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
         for i in 0..NUMBER_OF_PARTICIPANTS {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[i as usize],
                                                               &participants[i as usize].index.clone(),
                                                               &coefficients[i as usize],
@@ -367,7 +367,7 @@ mod sign_benches {
         let mut participants_states_2 = Vec::<DistributedKeyGeneration::<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
         for i in 0..NUMBER_OF_PARTICIPANTS {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[i as usize],
                                                               &participants[i as usize].index.clone(),
                                                               &coefficients[i as usize],

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -68,7 +68,7 @@ mod dkg_benches {
                                                          &p1_dh_sk,
                                                          &p1.index,
                                                          &coefficient,
-                                                         &mut participants,
+                                                         &participants,
                                                          "Φ"));
         });
     }
@@ -94,11 +94,11 @@ mod dkg_benches {
         let mut participants_states_2 = Vec::<DistributedKeyGeneration::<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
         for i in 0..NUMBER_OF_PARTICIPANTS {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
+            let (pi_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[i as usize],
                                                               &participants[i as usize].index.clone(),
                                                               &coefficients[i as usize],
-                                                              &mut participants,
+                                                              &participants,
                                                               "Φ").unwrap();
             let pi_their_encrypted_secret_shares = pi_state.their_encrypted_secret_shares().unwrap();
             participants_encrypted_secret_shares[i as usize] = pi_their_encrypted_secret_shares.clone();
@@ -144,8 +144,8 @@ mod dkg_benches {
         }
 
         for secret_key in participants_secret_keys.iter() {
-            let (dealer, _) =
-                Participant::reshare(&params, secret_key.clone(), &mut signers, "Φ").map_err(|_| ()).unwrap();
+            let (dealer, _, _) =
+                Participant::reshare(&params, secret_key.clone(), &signers, "Φ").map_err(|_| ()).unwrap();
             dealers.push(dealer);
         }
 
@@ -153,7 +153,7 @@ mod dkg_benches {
             b.iter(|| DistributedKeyGeneration::<_>::new(&params,
                                                          &s1_dh_sk,
                                                          &s1.index,
-                                                         &mut dealers,
+                                                         &dealers,
                                                          "Φ"));
         });
     }
@@ -174,21 +174,21 @@ mod dkg_benches {
 
         let mut p1_my_encrypted_secret_shares = Vec::<EncryptedSecretShare>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
-        let p1_state = DistributedKeyGeneration::<_>::new_initial(&params,
+        let (p1_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                           &dh_secret_keys[0],
                                                           &participants[0].index.clone(),
                                                           &coefficients[0],
-                                                          &mut participants,
+                                                          &participants,
                                                           "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
         p1_my_encrypted_secret_shares.push(p1_their_encrypted_secret_shares[0].clone());
 
         for i in 2..NUMBER_OF_PARTICIPANTS+1 {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
+            let (pi_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[(i-1) as usize],
                                                               &participants[(i-1) as usize].index.clone(),
                                                               &coefficients[(i-1) as usize],
-                                                              &mut participants,
+                                                              &participants,
                                                               "Φ").unwrap();
             let pi_their_encrypted_secret_shares = pi_state.their_encrypted_secret_shares().unwrap();
             p1_my_encrypted_secret_shares.push(pi_their_encrypted_secret_shares[0].clone());
@@ -215,21 +215,21 @@ mod dkg_benches {
 
         let mut p1_my_encrypted_secret_shares = Vec::<EncryptedSecretShare>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
-        let p1_state = DistributedKeyGeneration::<_>::new_initial(&params,
+        let (p1_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                           &dh_secret_keys[0],
                                                           &participants[0].index.clone(),
                                                           &coefficients[0],
-                                                          &mut participants,
+                                                          &participants,
                                                           "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
         p1_my_encrypted_secret_shares.push(p1_their_encrypted_secret_shares[0].clone());
 
         for i in 2..NUMBER_OF_PARTICIPANTS+1 {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
+            let (pi_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[(i-1) as usize],
                                                               &participants[(i-1) as usize].index.clone(),
                                                               &coefficients[(i-1) as usize],
-                                                              &mut participants,
+                                                              &participants,
                                                               "Φ").unwrap();
             let pi_their_encrypted_secret_shares = pi_state.their_encrypted_secret_shares().unwrap();
             p1_my_encrypted_secret_shares.push(pi_their_encrypted_secret_shares[0].clone());
@@ -263,11 +263,11 @@ mod dkg_benches {
         let mut participants_states_2 = Vec::<DistributedKeyGeneration::<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
         for i in 0..NUMBER_OF_PARTICIPANTS {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
+            let (pi_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[i as usize],
                                                               &participants[i as usize].index.clone(),
                                                               &coefficients[i as usize],
-                                                              &mut participants,
+                                                              &participants,
                                                               "Φ").unwrap();
             let pi_their_encrypted_secret_shares = pi_state.their_encrypted_secret_shares().unwrap();
             participants_encrypted_secret_shares[i as usize] = pi_their_encrypted_secret_shares.clone();
@@ -301,7 +301,7 @@ mod dkg_benches {
         }
 
         c.bench_function("Reshare", move |b| {
-            b.iter(|| Participant::reshare(&params, p1_sk.clone(), &mut signers, "Φ"));
+            b.iter(|| Participant::reshare(&params, p1_sk.clone(), &signers, "Φ"));
         });
     }
 
@@ -343,11 +343,11 @@ mod sign_benches {
         let mut participants_states_2 = Vec::<DistributedKeyGeneration::<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
         for i in 0..NUMBER_OF_PARTICIPANTS {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
+            let (pi_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[i as usize],
                                                               &participants[i as usize].index.clone(),
                                                               &coefficients[i as usize],
-                                                              &mut participants,
+                                                              &participants,
                                                               "Φ").unwrap();
             let pi_their_encrypted_secret_shares = pi_state.their_encrypted_secret_shares().unwrap();
             participants_encrypted_secret_shares[i as usize] = pi_their_encrypted_secret_shares.clone();
@@ -428,11 +428,11 @@ mod sign_benches {
         let mut participants_states_2 = Vec::<DistributedKeyGeneration::<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
         for i in 0..NUMBER_OF_PARTICIPANTS {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
+            let (pi_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[i as usize],
                                                               &participants[i as usize].index.clone(),
                                                               &coefficients[i as usize],
-                                                              &mut participants,
+                                                              &participants,
                                                               "Φ").unwrap();
             let pi_their_encrypted_secret_shares = pi_state.their_encrypted_secret_shares().unwrap();
             participants_encrypted_secret_shares[i as usize] = pi_their_encrypted_secret_shares.clone();
@@ -523,11 +523,11 @@ mod sign_benches {
         let mut participants_states_2 = Vec::<DistributedKeyGeneration::<_>>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
 
         for i in 0..NUMBER_OF_PARTICIPANTS {
-            let pi_state = DistributedKeyGeneration::<_>::new_initial(&params,
+            let (pi_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                               &dh_secret_keys[i as usize],
                                                               &participants[i as usize].index.clone(),
                                                               &coefficients[i as usize],
-                                                              &mut participants,
+                                                              &participants,
                                                               "Φ").unwrap();
             let pi_their_encrypted_secret_shares = pi_state.their_encrypted_secret_shares().unwrap();
             participants_encrypted_secret_shares[i as usize] = pi_their_encrypted_secret_shares.clone();

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -151,9 +151,9 @@ mod dkg_benches {
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
 
         c.bench_function("Finish", move |b| {
-            let pk = participants[0].public_key().unwrap();
+            let comm = &participants[0].commitments.points;
 
-            b.iter(|| p1_state.clone().finish(pk));
+            b.iter(|| p1_state.clone().finish(comm.clone()));
         });
     }
 
@@ -226,15 +226,15 @@ mod sign_benches {
         }
 
         let mut participants_secret_keys = Vec::<IndividualSecretKey>::with_capacity(THRESHOLD_OF_PARTICIPANTS as usize);
-        let (group_key, p1_sk) = participants_states_2[0].clone().finish(participants[1].public_key().unwrap()).unwrap();
+        let (group_key, p1_sk) = participants_states_2[0].clone().finish(participants[1].clone().commitments.points).unwrap();
         participants_secret_keys.push(p1_sk);
 
         for i in 2..THRESHOLD_OF_PARTICIPANTS+1 {
-            let (_, pi_sk) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].public_key().unwrap()).unwrap();
+            let (_, pi_sk) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].clone().commitments.points).unwrap();
             participants_secret_keys.push(pi_sk);
         }
         for i in (THRESHOLD_OF_PARTICIPANTS+2)..NUMBER_OF_PARTICIPANTS+1 {
-            let (_, _) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].public_key().unwrap()).unwrap();
+            let (_, _) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].clone().commitments.points).unwrap();
         }
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
@@ -318,15 +318,15 @@ mod sign_benches {
         }
 
         let mut participants_secret_keys = Vec::<IndividualSecretKey>::with_capacity(THRESHOLD_OF_PARTICIPANTS as usize);
-        let (group_key, p1_sk) = participants_states_2[0].clone().finish(participants[1].public_key().unwrap()).unwrap();
+        let (group_key, p1_sk) = participants_states_2[0].clone().finish(participants[1].clone().commitments.points).unwrap();
         participants_secret_keys.push(p1_sk);
 
         for i in 2..THRESHOLD_OF_PARTICIPANTS+1 {
-            let (_, pi_sk) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].public_key().unwrap()).unwrap();
+            let (_, pi_sk) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].clone().commitments.points).unwrap();
             participants_secret_keys.push(pi_sk);
         }
         for i in (THRESHOLD_OF_PARTICIPANTS+2)..NUMBER_OF_PARTICIPANTS+1 {
-            let (_, _) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].public_key().unwrap()).unwrap();
+            let (_, _) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].clone().commitments.points).unwrap();
         }
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
@@ -420,15 +420,15 @@ mod sign_benches {
         }
 
         let mut participants_secret_keys = Vec::<IndividualSecretKey>::with_capacity(THRESHOLD_OF_PARTICIPANTS as usize);
-        let (group_key, p1_sk) = participants_states_2[0].clone().finish(participants[1].public_key().unwrap()).unwrap();
+        let (group_key, p1_sk) = participants_states_2[0].clone().finish(participants[1].clone().commitments.points).unwrap();
         participants_secret_keys.push(p1_sk);
 
         for i in 2..THRESHOLD_OF_PARTICIPANTS+1 {
-            let (_, pi_sk) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].public_key().unwrap()).unwrap();
+            let (_, pi_sk) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].clone().commitments.points).unwrap();
             participants_secret_keys.push(pi_sk);
         }
         for i in (THRESHOLD_OF_PARTICIPANTS+2)..NUMBER_OF_PARTICIPANTS+1 {
-            let (_, _) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].public_key().unwrap()).unwrap();
+            let (_, _) = participants_states_2[(i-1) as usize].clone().finish(participants[(i-1) as usize].clone().commitments.points).unwrap();
         }
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -97,18 +97,29 @@
 //! //
 //! // Bob and Carol verify Alice's zero-knowledge proof by doing:
 //!
-//! alice.proof_of_secret_key.as_ref().unwrap().verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
+//! alice.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
 //!
 //! // Similarly, Alice and Carol verify Bob's proof:
-//! bob.proof_of_secret_key.as_ref().unwrap().verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
+//! bob.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
 //!
 //! // And, again, Alice and Bob verify Carol's proof:
-//! carol.proof_of_secret_key.as_ref().unwrap().verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
+//! carol.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
 //!
 //! // Alice enters round one of the distributed key generation protocol.
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coeffs,
-//!                                                      &mut participants, "Φ").or(Err(()))?;
+//! let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! let (alice_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &alice_dh_sk,
+//!         &alice.index,
+//!         &alice_coeffs,
+//!         &participants,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //!
 //! // Alice then collects the secret shares which they send to the other participants:
 //! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
@@ -117,9 +128,16 @@
 //! // send_to_carol(alice_their_encrypted_secret_shares[2]);
 //!
 //! // Bob enters round one of the distributed key generation protocol.
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coeffs,
-//!                                                    &mut participants, "Φ").or(Err(()))?;
+//! let (bob_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &bob_dh_sk,
+//!         &bob.index,
+//!         &bob_coeffs,
+//!         &participants,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //!
 //! // Bob then collects the secret shares which they send to the other participants:
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
@@ -128,9 +146,16 @@
 //! // send_to_carol(bob_their_encrypted_secret_shares[2]);
 //!
 //! // Carol enters round one of the distributed key generation protocol.
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coeffs,
-//!                                                      &mut participants, "Φ").or(Err(()))?;
+//! let (carol_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &carol_dh_sk,
+//!         &carol.index,
+//!         &carol_coeffs,
+//!         &participants,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //!
 //! // Carol then collects the secret shares which they send to the other participants:
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
@@ -180,9 +205,9 @@
 //! # Examples
 //!
 //! ```rust
-//! use frost_dalek::DistributedKeyGeneration;
-//! use frost_dalek::Parameters;
-//! use frost_dalek::Participant;
+//! use ice_frost::DistributedKeyGeneration;
+//! use ice_frost::Parameters;
+//! use ice_frost::Participant;
 //! use curve25519_dalek::ristretto::RistrettoPoint;
 //! use curve25519_dalek::traits::Identity;
 //! use curve25519_dalek::scalar::Scalar;
@@ -213,18 +238,29 @@
 //! //
 //! // Bob and Carol verify Alice's zero-knowledge proof by doing:
 //!
-//! alice.proof_of_secret_key.as_ref().unwrap().verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
+//! alice.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
 //!
 //! // Similarly, Alice and Carol verify Bob's proof:
-//! bob.proof_of_secret_key.as_ref().unwrap().verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
+//! bob.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
 //!
 //! // And, again, Alice and Bob verify Carol's proof:
-//! carol.proof_of_secret_key.as_ref().unwrap().verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
+//! carol.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
 //!
 //! // Alice enters round one of the distributed key generation protocol.
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coeffs,
-//!                                                      &mut participants, "Φ").or(Err(()))?;
+//! let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! let (alice_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &alice_dh_sk,
+//!         &alice.index,
+//!         &alice_coeffs,
+//!         &participants,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //!
 //! // Alice then collects the secret shares which they send to the other participants:
 //! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
@@ -233,9 +269,16 @@
 //! // send_to_carol(alice_their_encrypted_secret_shares[2]);
 //!
 //! // Bob enters round one of the distributed key generation protocol.
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coeffs,
-//!                                                    &mut participants, "Φ").or(Err(()))?;
+//! let (bob_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &bob_dh_sk,
+//!         &bob.index,
+//!         &bob_coeffs,
+//!         &participants,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //!
 //! // Bob then collects the secret shares which they send to the other participants:
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
@@ -244,9 +287,16 @@
 //! // send_to_carol(bob_their_encrypted_secret_shares[2]);
 //!
 //! // Carol enters round one of the distributed key generation protocol.
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coeffs,
-//!                                                      &mut participants, "Φ").or(Err(()))?;
+//! let (carol_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &carol_dh_sk,
+//!         &carol.index,
+//!         &carol_coeffs,
+//!         &participants,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //!
 //! // Carol then collects the secret shares which they send to the other participants:
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
@@ -328,39 +378,70 @@
 //! // Alice, Bob and Carol compute new secret shares of their long-lived secret signing key,
 //! // encrypted for Alexis, Barbara, Claire and David respectively.
 //! 
-//! let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! let (alice_as_dealer, alice_encrypted_shares) =
-//!     Participant::reshare(&new_params, alice_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! let signers: Vec<Participant> =
+//!     vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
+//! let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
+//!     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
 //! 
-//! let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! let (bob_as_dealer, bob_encrypted_shares) =
-//!     Participant::reshare(&new_params, bob_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
+//!     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
 //! 
-//! let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! let (carol_as_dealer, carol_encrypted_shares) =
-//!     Participant::reshare(&new_params, carol_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
+//!     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
 //! 
 //! // NOTE: They use the *new* configuration parameters (3-out-of-4) when resharing.
 //! 
 //! // Alexis, Barbara, Claire and Carol instantiate their DKG session with the set of dealers
 //! // who will compute their shares. They don't need to provide any coefficients.
-//! let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! let alexis_state = DistributedKeyGeneration::<_>::new(&params, &alexis_dh_sk, &alexis.index,
-//!                                                    &mut dealers, "Φ").or(Err(()))?;
+//! let dealers: Vec<Participant> =
+//!     vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
+//! let (alexis_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new(
+//!         &params,
+//!         &alexis_dh_sk,
+//!         &alexis.index,
+//!         &dealers,
+//!         "Φ"
+//!     )
+//!     .or(Err(()))?;
 //! 
-//! let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! let barbara_state = DistributedKeyGeneration::<_>::new(&params, &barbara_dh_sk, &barbara.index,
-//!                                                    &mut dealers, "Φ").or(Err(()))?;
+//! let (barbara_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new(
+//!         &params,
+//!         &barbara_dh_sk,
+//!         &barbara.index,
+//!         &dealers,
+//!         "Φ"
+//!     )
+//!     .or(Err(()))?;
 //! 
-//! let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! let claire_state = DistributedKeyGeneration::<_>::new(&params, &claire_dh_sk, &claire.index,
-//!                                                      &mut dealers, "Φ").or(Err(()))?;
+//! let (claire_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new(
+//!         &params,
+//!         &claire_dh_sk,
+//!         &claire.index,
+//!         &dealers,
+//!         "Φ"
+//!     )
+//!     .or(Err(()))?;
 //! 
-//! let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! let david_state = DistributedKeyGeneration::<_>::new(&params, &david_dh_sk, &david.index,
-//!                                                      &mut dealers, "Φ").or(Err(()))?;
+//! let (david_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new(
+//!         &params,
+//!         &david_dh_sk,
+//!         &david.index,
+//!         &dealers,
+//!         "Φ"
+//!     )
+//!     .or(Err(()))?;
 //! 
 //! // NOTE: They use the *old* configuration parameters (2-out-of-3) when instantiating their DKG.
+//! //       If some participants of the previous set (i.e. dealers here) have been discarded
+//! //       during their own DKG, signers need to update the *old* configuration parameters to
+//! //       take the number of total participants into account.
+//! //       For instance, if in a 201-out-of-300 setting, 37 participants had been discarded for
+//! //       misconduct, when new signers would refer to this previous set as dealers, they should
+//! //       set `params` to a 201-out-of-263 setting.
 //! 
 //! let alexis_my_encrypted_secret_shares = vec!(alice_encrypted_shares[0].clone(),
 //!                                   bob_encrypted_shares[0].clone(),
@@ -463,6 +544,10 @@ pub enum Error {
     MissingShares,
     /// At least one complaint has been issued during to_round_two() execution
     Complaint(Vec::<Complaint>),
+    /// Not all participants have been included
+    InvalidNumberOfParticipants(usize, u32),
+    /// Too many invalid participants, with their indices
+    TooManyInvalidParticipants(Vec::<u32>),
     /// Custom error
     Custom(String),
 }
@@ -490,6 +575,12 @@ impl fmt::Display for Error {
             },
             Error::Complaint(complaints) => {
                 write!(f, "{:?}", complaints)
+            },
+            Error::InvalidNumberOfParticipants(nb, n_params) => {
+                write!(f, "The number of participants {} does not match DKG instance parameters {}.", nb, n_params)
+            },
+            Error::TooManyInvalidParticipants(indices) => {
+                write!(f, "Too many invalid participants to continue the DKG: {:?}", indices)
             },
             Error::Custom(string) => {
                 write!(f, "{:?}", string)
@@ -873,6 +964,7 @@ impl Participant {
     ///
     /// * The *new* protocol instance [`Parameters`],
     /// * This participant's `secret_key`,
+    /// * A reference to the list of new participants,
     /// * A context string to prevent replay attacks.
     ///
     /// # Usage
@@ -884,17 +976,17 @@ impl Participant {
     ///
     /// # Returns
     ///
-    /// A distributed key generation protocol [`Participant`] and that
-    /// dealer's secret polynomial `Coefficients` along the dealer's
-    /// Diffie-Hellman private key for secret shares encryption which
-    /// must be kept private, and a `Vec<EncryptedSecretShare>` to be
-    /// sent to each participant of the new set accordingly.
+    /// A distributed key generation protocol [`Participant`], a
+    /// `Vec<EncryptedSecretShare>` to be sent to each participant
+    /// of the new set accordingly.
+    /// It also returns a list of the valid / misbehaving participants
+    /// of the new set for handling outside of this crate.
     pub fn reshare(
         parameters: &Parameters,
         secret_key: SecretKey,
-        signers: &mut Vec<Participant>,
+        signers: &[Participant],
         context_string: &str
-    ) -> Result<(Self, Vec<EncryptedSecretShare>), Vec<u32>>
+    ) -> Result<(Self, Vec<EncryptedSecretShare>, DKGParticipantList), Error>
     {
         let (dealer, coeff_option, dh_private_key) =
             Self::new_internal(parameters, false, secret_key.index, Some(secret_key.key), context_string);
@@ -902,7 +994,7 @@ impl Participant {
         // Unwrapping cannot panic here
         let coefficients = coeff_option.unwrap();
 
-        let participant_state = DistributedKeyGeneration::new_state_internal(
+        let (participant_state, participant_lists) = DistributedKeyGeneration::new_state_internal(
             parameters,
             &dh_private_key,
             &secret_key.index,
@@ -916,7 +1008,7 @@ impl Participant {
         // Unwrapping cannot panic here
         let encrypted_shares = participant_state.their_encrypted_secret_shares().unwrap().clone();
 
-        Ok((dealer, encrypted_shares))
+        Ok((dealer, encrypted_shares, participant_lists))
     }
 
     /// Retrieve \\( \alpha_{i0} * B \\), where \\( B \\) is the Ristretto basepoint.
@@ -1357,6 +1449,15 @@ fn decrypt_share(encrypted_share: &EncryptedSecretShare, aes_key: &[u8; 32]) -> 
 #[derive(Clone, Debug)]
 pub struct RoundOne {}
 
+/// Output of the first round of the Distributed Key Generation.
+#[derive(Clone, Debug)]
+pub struct DKGParticipantList {
+    /// List of the valid participants to be used in RoundTwo
+    pub valid_participants: Vec<Participant>,
+    /// List of the invalid participants that have been removed
+    pub misbehaving_participants: Option<Vec<u32>>,
+}
+
 impl DistributedKeyGeneration<RoundOne> {
     /// Check the zero-knowledge proofs of knowledge of secret keys of all the
     /// other participants. When no group key has been computed by a group of
@@ -1377,16 +1478,16 @@ impl DistributedKeyGeneration<RoundOne> {
         dh_private_key: &DHPrivateKey,
         my_index: &u32,
         my_coefficients: &Coefficients,
-        participants: &mut Vec<Participant>,
+        participants: &[Participant],
         context_string: &str,
-    ) -> Result<Self, Vec<u32>>
+    ) -> Result<(Self, DKGParticipantList), Error>
     {
         Self::new_state_internal(
             parameters,
             dh_private_key,
             my_index,
             Some(my_coefficients),
-            participants,
+            &participants,
             context_string,
             true,
             true,
@@ -1411,16 +1512,16 @@ impl DistributedKeyGeneration<RoundOne> {
         parameters: &Parameters,
         dh_private_key: &DHPrivateKey,
         my_index: &u32,
-        dealers: &mut Vec<Participant>,
+        dealers: &[Participant],
         context_string: &str,
-    ) -> Result<Self, Vec<u32>>
+    ) -> Result<(Self, DKGParticipantList), Error>
     {
         Self::new_state_internal(
             parameters,
             dh_private_key,
             my_index,
             None,
-            dealers,
+            &dealers,
             context_string,
             false,
             true,
@@ -1432,21 +1533,22 @@ impl DistributedKeyGeneration<RoundOne> {
         dh_private_key: &DHPrivateKey,
         my_index: &u32,
         my_coefficients: Option<&Coefficients>,
-        participants: &mut Vec<Participant>,
+        participants: &[Participant],
         context_string: &str,
         from_dealer: bool,
         from_signer: bool,
-    ) -> Result<Self, Vec<u32>>
+    ) -> Result<(Self, DKGParticipantList), Error>
     {
         let mut their_commitments: Vec<VerifiableSecretSharingCommitment> = Vec::with_capacity(parameters.t as usize);
         let mut their_dh_public_keys: Vec<(u32, DHPublicKey)> = Vec::with_capacity(parameters.t as usize);
+        let mut valid_participants: Vec<Participant> = Vec::with_capacity(parameters.n as usize);
         let mut misbehaving_participants: Vec<u32> = Vec::new();
 
         let dh_public_key = DHPublicKey(&RISTRETTO_BASEPOINT_TABLE * &dh_private_key);
 
         // Bail if we didn't get enough participants.
         if participants.len() != parameters.n as usize {
-            return Err(misbehaving_participants);
+            return Err(Error::InvalidNumberOfParticipants(participants.len(), parameters.n));
         }
 
         // Check the public keys and the DH keys of the participants.
@@ -1465,12 +1567,14 @@ impl DistributedKeyGeneration<RoundOne> {
                         };
                         match p.proof_of_secret_key.as_ref().unwrap().verify(&p.index, &public_key, &context_string) {
                             Ok(_)  => {
+                                valid_participants.push(p.clone());
                                 their_commitments.push(p.commitments.as_ref().unwrap().clone());
                                 their_dh_public_keys.push((p.index, p.dh_public_key.clone()));
                             },
                             Err(_) => misbehaving_participants.push(p.index),
                         }
                     } else {
+                        valid_participants.push(p.clone());
                         their_dh_public_keys.push((p.index, p.dh_public_key.clone()));
                     }
                 },
@@ -1478,9 +1582,9 @@ impl DistributedKeyGeneration<RoundOne> {
             }
         }
 
-        // [DIFFERENT_TO_PAPER] If any participant was misbehaving, return their indices.
-        if !misbehaving_participants.is_empty() {
-            return Err(misbehaving_participants);
+        // [DIFFERENT_TO_PAPER] If too many participants were misbehaving, return an error along their indices.
+        if valid_participants.len() < parameters.t as usize {
+            return Err(Error::TooManyInvalidParticipants(misbehaving_participants));
         }
 
         if !from_dealer && from_signer {
@@ -1496,10 +1600,21 @@ impl DistributedKeyGeneration<RoundOne> {
             };
 
             return Ok(
-                DistributedKeyGeneration::<RoundOne> {
-                    state: Box::new(state),
-                    data: RoundOne {},
-                }
+                (
+                    DistributedKeyGeneration::<RoundOne> {
+                        state: Box::new(state),
+                        data: RoundOne {},
+                    },
+                    DKGParticipantList {
+                        valid_participants,
+                        misbehaving_participants:
+                            if misbehaving_participants.len() == 0 {
+                                None
+                            } else {
+                                Some(misbehaving_participants)
+                            },
+                    }
+                )
             )
         }
 
@@ -1532,10 +1647,23 @@ impl DistributedKeyGeneration<RoundOne> {
             my_secret_shares: None,
         };
 
-        Ok(DistributedKeyGeneration::<RoundOne> {
-            state: Box::new(state),
-            data: RoundOne {},
-        })
+        Ok(
+            (
+                DistributedKeyGeneration::<RoundOne> {
+                    state: Box::new(state),
+                    data: RoundOne {},
+                },
+                DKGParticipantList {
+                    valid_participants,
+                    misbehaving_participants:
+                        if misbehaving_participants.len() == 0 {
+                            None
+                        } else {
+                            Some(misbehaving_participants)
+                        },
+                }
+            )
+        )
     }
 
     /// Retrieve an encrypted secret share for each other participant, to be given to them
@@ -2400,12 +2528,12 @@ mod test {
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
-        let mut participants: Vec<Participant> = vec![p1.clone()];
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let participants: Vec<Participant> = vec![p1.clone()];
+        let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
@@ -2434,44 +2562,44 @@ mod test {
         p4.proof_of_secret_key.as_ref().unwrap().verify(&p4.index, &p4.public_key().unwrap(), "Φ").unwrap();
         p5.proof_of_secret_key.as_ref().unwrap().verify(&p5.index, &p5.public_key().unwrap(), "Φ").unwrap();
 
-        let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
+        let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                   &p3_dh_sk,
                                                                   &p3.index,
                                                                   &p3coeffs,
-                                                                  &mut participants,
+                                                                  &participants,
                                                                   "Φ").unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-        let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p4_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
                                                                  &p4coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-        let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p5_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
                                                                  &p5coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
@@ -2550,28 +2678,28 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
-                                                                      &mut participants,
+                                                                      &participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
@@ -2614,28 +2742,28 @@ mod test {
             dealer2.proof_of_secret_key.as_ref().unwrap().verify(&dealer2.index, &dealer2.public_key().unwrap(), "Φ").or(Err(()))?;
             dealer3.proof_of_secret_key.as_ref().unwrap().verify(&dealer3.index, &dealer3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
-            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
+            let (dealer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer1_dh_sk,
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares()?;
 
-            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (dealer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer2_dh_sk,
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares()?;
 
-            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (dealer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer3_dh_sk,
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer3_their_encrypted_secret_shares = dealer3_state.their_encrypted_secret_shares()?;
 
@@ -2665,32 +2793,32 @@ mod test {
             // Dealer 3 is also a participant of the next set of signers
             let (signer3, signer3_dh_sk) = (dealer3.clone(), dealer3_dh_sk);
 
-            let mut signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone());
+            let signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone());
 
-            let (dealer1_for_signers, dealer1_encrypted_shares_for_signers) =
-                Participant::reshare(&params, dealer1_secret_key, &mut signers, "Φ").map_err(|_| ())?;
-            let (dealer2_for_signers, dealer2_encrypted_shares_for_signers) =
-                Participant::reshare(&params, dealer2_secret_key, &mut signers, "Φ").map_err(|_| ())?;
-            let (dealer3_for_signers, dealer3_encrypted_shares_for_signers) =
-                Participant::reshare(&params, dealer3_secret_key, &mut signers, "Φ").map_err(|_| ())?;
+            let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params, dealer1_secret_key, &&signers, "Φ").map_err(|_| ())?;
+            let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params, dealer2_secret_key, &&signers, "Φ").map_err(|_| ())?;
+            let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params, dealer3_secret_key, &&signers, "Φ").map_err(|_| ())?;
 
-            let mut dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
-            let signer1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
+            let (signer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer2_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let (signer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer3_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let (signer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
             let signer1_my_encrypted_secret_shares = vec!(dealer1_encrypted_shares_for_signers[0].clone(),
@@ -2734,28 +2862,28 @@ mod test {
             dealer2.proof_of_secret_key.as_ref().unwrap().verify(&dealer2.index, &dealer2.public_key().unwrap(), "Φ").or(Err(()))?;
             dealer3.proof_of_secret_key.as_ref().unwrap().verify(&dealer3.index, &dealer3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
-            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
+            let dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
+            let (dealer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer1_dh_sk,
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares()?;
 
-            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
+            let (dealer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer2_dh_sk,
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares()?;
 
-            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
+            let (dealer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer3_dh_sk,
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer3_their_encrypted_secret_shares = dealer3_state.their_encrypted_secret_shares()?;
 
@@ -2787,44 +2915,44 @@ mod test {
             let (signer4, signer4_dh_sk) = Participant::new_signer(&params_signers, 4, "Φ");
             let (signer5, signer5_dh_sk) = Participant::new_signer(&params_signers, 5, "Φ");
 
-            let mut signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone(), signer4.clone(), signer5.clone());
+            let signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone(), signer4.clone(), signer5.clone());
 
-            let (dealer1_for_signers, dealer1_encrypted_shares_for_signers) =
-                Participant::reshare(&params_signers, dealer1_secret_key, &mut signers, "Φ").map_err(|_| ())?;
-            let (dealer2_for_signers, dealer2_encrypted_shares_for_signers) =
-                Participant::reshare(&params_signers, dealer2_secret_key, &mut signers, "Φ").map_err(|_| ())?;
-            let (dealer3_for_signers, dealer3_encrypted_shares_for_signers) =
-                Participant::reshare(&params_signers, dealer3_secret_key, &mut signers, "Φ").map_err(|_| ())?;
+            let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params_signers, dealer1_secret_key, &&signers, "Φ").map_err(|_| ())?;
+            let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params_signers, dealer2_secret_key, &&signers, "Φ").map_err(|_| ())?;
+            let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params_signers, dealer3_secret_key, &&signers, "Φ").map_err(|_| ())?;
 
-            let mut dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
-            let signer1_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
+            let (signer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer2_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let (signer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer3_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let (signer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer4_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let (signer4_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer4_dh_sk,
                                                                      &signer4.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer5_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let (signer5_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer5_dh_sk,
                                                                      &signer5.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
             let signer1_my_encrypted_secret_shares = vec!(dealer1_encrypted_shares_for_signers[0].clone(),
@@ -2898,28 +3026,28 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dh_sk1,
                                                                      &p1.index,
                                                                      &p1coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dh_sk2,
                                                                      &p2.index,
                                                                      &p2coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &dh_sk3,
                                                                       &p3.index,
                                                                       &p3coeffs,
-                                                                      &mut participants,
+                                                                      &participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
@@ -2962,28 +3090,28 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dh_sk1,
                                                                      &p1.index,
                                                                      &p1coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dh_sk2,
                                                                      &p2.index,
                                                                      &p2coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &dh_sk3,
                                                                       &p3.index,
                                                                       &p3coeffs,
-                                                                      &mut participants,
+                                                                      &participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
@@ -3144,28 +3272,28 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
-                                                                      &mut participants,
+                                                                      &participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
@@ -3290,28 +3418,28 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
-                                                                      &mut participants,
+                                                                      &participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -2080,7 +2080,7 @@ impl DistributedKeyGeneration<RoundTwo> {
     /// # Example
     ///
     /// ```ignore
-    /// let (group_key, secret_key) = state.finish(participant.public_key()?)?;
+    /// let (group_key, secret_key) = state.finish()?;
     /// ```
     pub fn finish(mut self) -> Result<(GroupKey, SecretKey), Error> {
         let secret_key = self.calculate_signing_key()?;
@@ -2105,9 +2105,6 @@ impl DistributedKeyGeneration<RoundTwo> {
             index_vector.push(share.sender_index);
         }
 
-        // This time you don't use your own index!
-        // index_vector.push(self.state.my_secret_share.sender_index);
-
         let mut key = Scalar::zero();
 
         for share in my_secret_shares.iter() {
@@ -2117,14 +2114,6 @@ impl DistributedKeyGeneration<RoundTwo> {
             };
             key += share.polynomial_evaluation * coeff;
         }
-
-        // You don't use your secret share in the computation.
-        /* let my_coeff = match calculate_lagrange_coefficients(&self.state.my_secret_share.sender_index, &index_vector) {
-                Ok(s) => s,
-                Err(error) => return Err(Error::Custom(error.to_string())),
-            };
-
-        key += self.state.my_secret_share.polynomial_evaluation * my_coeff; */
 
         Ok(SecretKey { index: self.state.index, key })
     }

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -958,6 +958,101 @@ impl DistributedKeyGeneration<RoundOne> {
     /// An updated state machine for the distributed key generation protocol if
     /// all of the zero-knowledge proofs verified successfully, otherwise a
     /// vector of participants whose zero-knowledge proofs were incorrect.
+    pub fn new_initial_state(
+        parameters: &Parameters,
+        dh_private_key: &DHPrivateKey,
+        my_index: &u32,
+        my_coefficients: &Coefficients,
+        participants: &mut Vec<Participant>,
+        context_string: &str,
+    ) -> Result<Self, Vec<u32>>
+    {
+        let mut their_commitments: Vec<VerifiableSecretSharingCommitment> = Vec::with_capacity(parameters.t as usize);
+        let mut their_dh_public_keys: Vec<(u32, DHPublicKey)> = Vec::with_capacity(parameters.t as usize);
+        let mut misbehaving_participants: Vec<u32> = Vec::new();
+
+        let dh_public_key = DHPublicKey(&RISTRETTO_BASEPOINT_TABLE * &dh_private_key);
+
+        // Bail if we didn't get enough participants.
+        if participants.len() != parameters.n as usize {
+            return Err(misbehaving_participants);
+        }
+
+        // Check the public keys and the DH keys of the participants.
+        for p in participants.iter() {
+            let public_key = match p.public_key() {
+                Some(key) => key,
+                None      => {
+                    misbehaving_participants.push(p.index);
+                    continue;
+                }
+            };
+            match p.proof_of_secret_key.as_ref().unwrap().verify(&p.index, &public_key, &context_string) {
+                Ok(_)  => {
+                            their_commitments.push(p.commitments.as_ref().unwrap().clone());
+                            their_dh_public_keys.push((p.index, p.dh_public_key.clone()));
+
+                            match p.proof_of_dh_private_key.verify(&p.index, &p.dh_public_key, &context_string) {
+                                Ok(_)  => (),
+                                Err(_) => misbehaving_participants.push(p.index),
+                            }
+                          },
+                Err(_) => misbehaving_participants.push(p.index),
+            }
+        }
+
+        // [DIFFERENT_TO_PAPER] If any participant was misbehaving, return their indices.
+        if !misbehaving_participants.is_empty() {
+            return Err(misbehaving_participants);
+        }
+
+        // [DIFFERENT_TO_PAPER] We pre-calculate the secret shares from Round 2
+        // Step 1 here since it doesn't require additional online activity.
+        // RICE-FROST: We also encrypt them into their_encrypted_secret_shares.
+        //
+        // Round 2
+        // Step 1: Each P_i securely sends to each other participant P_l a secret share
+        //         (l, f_i(l)) and keeps (i, f_i(i)) for themselves.
+        let mut their_encrypted_secret_shares: Vec<EncryptedSecretShare> = Vec::with_capacity(parameters.n as usize - 1);
+
+        // XXX need a way to index their_encrypted_secret_shares
+        for p in participants.iter() {
+            let share = SecretShare::evaluate_polynomial(my_index, &p.index, my_coefficients);
+
+            let dh_key = (p.dh_public_key.0 * dh_private_key.0).compress().to_bytes();
+
+            their_encrypted_secret_shares.push(encrypt_share(&share, &dh_key));
+        }
+
+        let state = ActualState {
+            parameters: *parameters,
+            index: *my_index,
+            dh_private_key: dh_private_key.clone(),
+            dh_public_key,
+            their_commitments: Some(their_commitments),
+            their_dh_public_keys,
+            their_encrypted_secret_shares: Some(their_encrypted_secret_shares),
+            my_secret_shares: None,
+        };
+
+        Ok(DistributedKeyGeneration::<RoundOne> {
+            state: Box::new(state),
+            data: RoundOne {},
+        })
+    }
+
+    /// Check the zero-knowledge proofs of knowledge of secret keys of all the
+    /// other participants.
+    ///
+    /// # Note
+    ///
+    /// The `participants` will be sorted by their indices.
+    ///
+    /// # Returns
+    ///
+    /// An updated state machine for the distributed key generation protocol if
+    /// all of the zero-knowledge proofs verified successfully, otherwise a
+    /// vector of participants whose zero-knowledge proofs were incorrect.
     pub fn new_dealer_state(
         parameters: &Parameters,
         dh_private_key: &DHPrivateKey,
@@ -967,7 +1062,6 @@ impl DistributedKeyGeneration<RoundOne> {
         context_string: &str,
     ) -> Result<Self, Vec<u32>>
     {
-        let mut their_commitments: Vec<VerifiableSecretSharingCommitment> = Vec::with_capacity(parameters.t as usize);
         let mut their_dh_public_keys: Vec<(u32, DHPublicKey)> = Vec::with_capacity(parameters.t as usize);
         let mut misbehaving_signers: Vec<u32> = Vec::new();
 
@@ -1015,7 +1109,7 @@ impl DistributedKeyGeneration<RoundOne> {
             index: *my_index,
             dh_private_key: dh_private_key.clone(),
             dh_public_key,
-            their_commitments: Some(their_commitments),
+            their_commitments: None,
             their_dh_public_keys,
             their_encrypted_secret_shares: Some(their_encrypted_secret_shares),
             my_secret_shares: None,
@@ -1584,17 +1678,10 @@ impl DistributedKeyGeneration<RoundTwo> {
             index_vector.push(commitment.index);
         }
 
-        // This time you don't use your own index!
-        // index_vector.push(self.state.my_secret_share.sender_index);
-
-        let all_commitments = self.state.their_commitments.as_ref().unwrap().clone();
-        // all_commitments.push((self.state.my_secret_share.sender_index, VerifiableSecretSharingCommitment(my_commitment)));
-
         let mut group_key = RistrettoPoint::identity();
 
         // The group key is the interpolation at 0 of all index 0 of the dealers' commitments.
-
-        for commitment in all_commitments.iter() {
+        for commitment in self.state.their_commitments.as_ref().unwrap().iter() {
             let coeff = match calculate_lagrange_coefficients(&commitment.index, &index_vector) {
                 Ok(s) => s,
                 Err(error) => return Err(Error::Custom(error.to_string())),
@@ -1958,14 +2045,14 @@ mod test {
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
-        let mut p1_other_participants: Vec<Participant> = Vec::new();
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let mut participants: Vec<Participant> = vec![p1.clone()];
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs.unwrap(),
-                                                                 &mut p1_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
-        let p1_my_encrypted_secret_shares = Vec::new();
+        let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
         let result = p1_state.finish();
 
@@ -1993,7 +2080,7 @@ mod test {
         p5.proof_of_secret_key.as_ref().unwrap().verify(&p5.index, &p5.public_key().unwrap(), "Φ").unwrap();
 
         let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs.unwrap(),
@@ -2001,7 +2088,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs.unwrap(),
@@ -2009,7 +2096,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                   &p3_dh_sk,
                                                                   &p3.index,
                                                                   &p3coeffs.unwrap(),
@@ -2017,7 +2104,7 @@ mod test {
                                                                   "Φ").unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-        let p4_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
                                                                  &p4coeffs.unwrap(),
@@ -2025,7 +2112,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-        let p5_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
                                                                  &p5coeffs.unwrap(),
@@ -2108,39 +2195,40 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs.unwrap(),
-                                                                     &mut p1_other_participants,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs.unwrap(),
-                                                                     &mut p2_other_participants,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs.unwrap(),
-                                                                      &mut p3_other_participants,
+                                                                      &mut participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
-            let p1_my_encrypted_secret_shares = vec!(p2_their_encrypted_secret_shares[0].clone(), // XXX FIXME indexing
+            let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+                                           p2_their_encrypted_secret_shares[0].clone(),
                                            p3_their_encrypted_secret_shares[0].clone());
-            let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+            let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
+                                           p2_their_encrypted_secret_shares[1].clone(),
                                            p3_their_encrypted_secret_shares[1].clone());
-            let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
-                                           p2_their_encrypted_secret_shares[1].clone());
+            let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
+                                           p2_their_encrypted_secret_shares[2].clone(),
+                                           p3_their_encrypted_secret_shares[2].clone());
 
             let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
@@ -2300,39 +2388,40 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &dh_sk1,
                                                                      &p1.index,
                                                                      &p1coeffs.unwrap(),
-                                                                     &mut p1_other_participants,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &dh_sk2,
                                                                      &p2.index,
                                                                      &p2coeffs.unwrap(),
-                                                                     &mut p2_other_participants,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                       &dh_sk3,
                                                                       &p3.index,
                                                                       &p3coeffs.unwrap(),
-                                                                      &mut p3_other_participants,
+                                                                      &mut participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
-            let p1_my_encrypted_secret_shares = vec!(p2_their_encrypted_secret_shares[0].clone(), // XXX FIXME indexing
+            let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+                                           p2_their_encrypted_secret_shares[0].clone(),
                                            p3_their_encrypted_secret_shares[0].clone());
-            let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+            let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
+                                           p2_their_encrypted_secret_shares[1].clone(),
                                            p3_their_encrypted_secret_shares[1].clone());
-            let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
-                                           p2_their_encrypted_secret_shares[1].clone());
+            let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
+                                           p2_their_encrypted_secret_shares[2].clone(),
+                                           p3_their_encrypted_secret_shares[2].clone());
 
             let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
@@ -2363,30 +2452,28 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &dh_sk1,
                                                                      &p1.index,
                                                                      &p1coeffs.unwrap(),
-                                                                     &mut p1_other_participants,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &dh_sk2,
                                                                      &p2.index,
                                                                      &p2coeffs.unwrap(),
-                                                                     &mut p2_other_participants,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                       &dh_sk3,
                                                                       &p3.index,
                                                                       &p3coeffs.unwrap(),
-                                                                      &mut p3_other_participants,
+                                                                      &mut participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -107,7 +107,7 @@
 //!
 //! // Alice enters round one of the distributed key generation protocol.
 //! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coeffs,
+//! let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coeffs,
 //!                                                      &mut participants, "Φ").or(Err(()))?;
 //!
 //! // Alice then collects the secret shares which they send to the other participants:
@@ -118,7 +118,7 @@
 //!
 //! // Bob enters round one of the distributed key generation protocol.
 //! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coeffs,
+//! let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coeffs,
 //!                                                    &mut participants, "Φ").or(Err(()))?;
 //!
 //! // Bob then collects the secret shares which they send to the other participants:
@@ -129,7 +129,7 @@
 //!
 //! // Carol enters round one of the distributed key generation protocol.
 //! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coeffs,
+//! let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coeffs,
 //!                                                      &mut participants, "Φ").or(Err(()))?;
 //!
 //! // Carol then collects the secret shares which they send to the other participants:
@@ -1136,7 +1136,9 @@ pub struct RoundOne {}
 
 impl DistributedKeyGeneration<RoundOne> {
     /// Check the zero-knowledge proofs of knowledge of secret keys of all the
-    /// other participants.
+    /// other participants. When no group key has been computed by a group of
+    /// participants yet, this method should be called rather than 
+    /// `DistributedKeyGeneration<RoundOne>::new()`.
     ///
     /// # Note
     ///
@@ -1147,7 +1149,7 @@ impl DistributedKeyGeneration<RoundOne> {
     /// An updated state machine for the distributed key generation protocol if
     /// all of the zero-knowledge proofs verified successfully, otherwise a
     /// vector of participants whose zero-knowledge proofs were incorrect.
-    pub fn new_initial_state(
+    pub fn new_initial(
         parameters: &Parameters,
         dh_private_key: &DHPrivateKey,
         my_index: &u32,
@@ -1169,7 +1171,9 @@ impl DistributedKeyGeneration<RoundOne> {
     }
 
     /// Check the zero-knowledge proofs of knowledge of secret keys of all the
-    /// other participants.
+    /// other participants. When a group key already exists and dealers have
+    /// distributed secret shares to a new set, participants of this new set
+    /// should call this method.
     ///
     /// # Note
     ///
@@ -1180,7 +1184,7 @@ impl DistributedKeyGeneration<RoundOne> {
     /// An updated state machine for the distributed key generation protocol if
     /// all of the zero-knowledge proofs verified successfully, otherwise a
     /// vector of participants whose zero-knowledge proofs were incorrect.
-    pub fn new_signer_state(
+    pub fn new(
         parameters: &Parameters,
         dh_private_key: &DHPrivateKey,
         my_index: &u32,
@@ -2174,7 +2178,7 @@ mod test {
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
         let mut participants: Vec<Participant> = vec![p1.clone()];
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -2208,7 +2212,7 @@ mod test {
         p5.proof_of_secret_key.as_ref().unwrap().verify(&p5.index, &p5.public_key().unwrap(), "Φ").unwrap();
 
         let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -2216,7 +2220,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs,
@@ -2224,7 +2228,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                   &p3_dh_sk,
                                                                   &p3.index,
                                                                   &p3coeffs,
@@ -2232,7 +2236,7 @@ mod test {
                                                                   "Φ").unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-        let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
                                                                  &p4coeffs,
@@ -2240,7 +2244,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-        let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
                                                                  &p5coeffs,
@@ -2324,7 +2328,7 @@ mod test {
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -2332,7 +2336,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -2340,7 +2344,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
@@ -2388,7 +2392,7 @@ mod test {
             dealer3.proof_of_secret_key.as_ref().unwrap().verify(&dealer3.index, &dealer3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
-            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer1_dh_sk,
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
@@ -2396,7 +2400,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares()?;
 
-            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer2_dh_sk,
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
@@ -2404,7 +2408,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares()?;
 
-            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer3_dh_sk,
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
@@ -2448,19 +2452,19 @@ mod test {
                 Participant::reshare(&params, dealer3_secret_key, &mut signers, "Φ").map_err(|_| ())?;
 
             let mut dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
-            let signer1_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params,
+            let signer1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer2_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params,
+            let signer2_state = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer3_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params,
+            let signer3_state = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
                                                                      &mut dealers,
@@ -2508,7 +2512,7 @@ mod test {
             dealer3.proof_of_secret_key.as_ref().unwrap().verify(&dealer3.index, &dealer3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
-            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params_dealers,
+            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer1_dh_sk,
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
@@ -2516,7 +2520,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares()?;
 
-            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params_dealers,
+            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer2_dh_sk,
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
@@ -2524,7 +2528,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares()?;
 
-            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params_dealers,
+            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer3_dh_sk,
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
@@ -2570,31 +2574,31 @@ mod test {
                 Participant::reshare(&params_signers, dealer3_secret_key, &mut signers, "Φ").map_err(|_| ())?;
 
             let mut dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
-            let signer1_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer1_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer2_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer2_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer3_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer3_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer4_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer4_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer4_dh_sk,
                                                                      &signer4.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer5_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer5_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer5_dh_sk,
                                                                      &signer5.index,
                                                                      &mut dealers,
@@ -2672,7 +2676,7 @@ mod test {
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dh_sk1,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -2680,7 +2684,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dh_sk2,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -2688,7 +2692,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &dh_sk3,
                                                                       &p3.index,
                                                                       &p3coeffs,
@@ -2736,7 +2740,7 @@ mod test {
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dh_sk1,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -2744,7 +2748,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dh_sk2,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -2752,7 +2756,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &dh_sk3,
                                                                       &p3.index,
                                                                       &p3coeffs,
@@ -2918,7 +2922,7 @@ mod test {
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -2926,7 +2930,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -2934,7 +2938,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
@@ -3064,7 +3068,7 @@ mod test {
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -3072,7 +3076,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -3080,7 +3084,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //!
 //! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
 //!                                                      &mut participants, "Φ")?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
@@ -181,7 +181,7 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //!
@@ -208,7 +208,7 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
 //!                                                    &mut participants, "Φ")?;
 //! # Ok(()) }
 //! # fn do_test2() -> Result<(), ()> {
@@ -219,7 +219,7 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
 //! #                                                    &mut participants, "Φ").or(Err(()))?;
 //!
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
@@ -247,7 +247,7 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //!                                                      &mut participants, "Φ")?;
 //! # Ok(()) }
 //! # fn do_test2() -> Result<(), ()> {
@@ -258,7 +258,7 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //!
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
@@ -286,17 +286,17 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
 //! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
@@ -330,17 +330,17 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
 //! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
@@ -379,17 +379,17 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
 //! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
@@ -447,17 +447,17 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
 //! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
@@ -525,17 +525,17 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
 //! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
@@ -606,17 +606,17 @@
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(""))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(""))?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
 //! #                                                    &mut participants, "Φ").or(Err(""))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(""))?;
 //! #
 //! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
 //! #                                                      &mut participants, "Φ").or(Err(""))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(""))?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,9 @@
 //! #
 //! # let params = Parameters { t: 2, n: 3 };
 //! 
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! ```
 //!
 //! They send these values to each of the other participants (also out of scope
@@ -94,11 +94,11 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! alice.proof_of_secret_key.verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
+//! alice.proof_of_secret_key.as_ref().unwrap().verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -113,11 +113,11 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! bob.proof_of_secret_key.verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
+//! bob.proof_of_secret_key.as_ref().unwrap().verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -132,11 +132,11 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! carol.proof_of_secret_key.verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
+//! carol.proof_of_secret_key.as_ref().unwrap().verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -153,13 +153,13 @@
 //! # fn do_test() -> Result<(), Vec<u32>> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //!
-//! let mut alice_other_participants: Vec<Participant> = vec!(bob.clone(), carol.clone());
-//! let alice_state = DistributedKeyGeneration::<_>::new(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//!                                                      &mut alice_other_participants, "Φ")?;
+//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//!                                                      &mut participants, "Φ")?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -176,13 +176,13 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut alice_other_participants: Vec<Participant> = vec!(bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut alice_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //!
 //! // send_to_bob(alice_their_encrypted_secret_shares[0]);
@@ -203,24 +203,24 @@
 //! # fn do_test() -> Result<(), Vec<u32>> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! let mut bob_other_participants: Vec<Participant> = vec!(alice.clone(), carol.clone());
-//! let bob_state = DistributedKeyGeneration::<_>::new(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//!                                                    &mut bob_other_participants, "Φ")?;
+//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//!                                                    &mut participants, "Φ")?;
 //! # Ok(()) }
 //! # fn do_test2() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut bob_other_participants: Vec<Participant> = vec!(alice.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut bob_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &mut participants, "Φ").or(Err(()))?;
 //!
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //!
@@ -242,24 +242,24 @@
 //! # fn do_test() -> Result<(), Vec<u32>> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! let mut carol_other_participants: Vec<Participant> = vec!(alice.clone(), bob.clone());
-//! let carol_state = DistributedKeyGeneration::<_>::new(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//!                                                      &mut carol_other_participants, "Φ")?;
+//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//!                                                      &mut participants, "Φ")?;
 //! # Ok(()) }
 //! # fn do_test2() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut carol_other_participants: Vec<Participant> = vec!(alice.clone(), bob.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut carol_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //!
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //!
@@ -281,30 +281,33 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut alice_other_participants: Vec<Participant> = vec!(bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut alice_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut bob_other_participants: Vec<Participant> = vec!(alice.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut bob_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut carol_other_participants: Vec<Participant> = vec!(alice.clone(), bob.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut carol_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! let alice_my_encrypted_secret_shares = vec!(bob_their_encrypted_secret_shares[0].clone(),
+//! let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//!                                   bob_their_encrypted_secret_shares[0].clone(),
 //!                                   carol_their_encrypted_secret_shares[0].clone());
-//! let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
+//!                                 bob_their_encrypted_secret_shares[1].clone(),
 //!                                 carol_their_encrypted_secret_shares[1].clone());
-//! let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
-//!                                   bob_their_encrypted_secret_shares[1].clone());
+//! let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[2].clone(),
+//!                                   bob_their_encrypted_secret_shares[2].clone(),
+//!                                   carol_their_encrypted_secret_shares[2].clone());
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -322,30 +325,33 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut alice_other_participants: Vec<Participant> = vec!(bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut alice_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut bob_other_participants: Vec<Participant> = vec!(alice.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut bob_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut carol_other_participants: Vec<Participant> = vec!(alice.clone(), bob.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut carol_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec!(bob_their_encrypted_secret_shares[0].clone(),
+//! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
-//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
+//! #                                 bob_their_encrypted_secret_shares[1].clone(),
 //! #                                 carol_their_encrypted_secret_shares[1].clone());
-//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
-//! #                                   bob_their_encrypted_secret_shares[1].clone());
+//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[2].clone(),
+//! #                                   bob_their_encrypted_secret_shares[2].clone(),
+//! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
 //! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
 //! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
@@ -368,38 +374,41 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut alice_other_participants: Vec<Participant> = vec!(bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut alice_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut bob_other_participants: Vec<Participant> = vec!(alice.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut bob_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut carol_other_participants: Vec<Participant> = vec!(alice.clone(), bob.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut carol_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec!(bob_their_encrypted_secret_shares[0].clone(),
+//! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
-//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
+//! #                                 bob_their_encrypted_secret_shares[1].clone(),
 //! #                                 carol_their_encrypted_secret_shares[1].clone());
-//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
-//! #                                   bob_their_encrypted_secret_shares[1].clone());
+//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[2].clone(),
+//! #                                   bob_their_encrypted_secret_shares[2].clone(),
+//! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
 //! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
 //! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
 //! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
 //! #
-//! let (alice_group_key, alice_secret_key) = alice_state.finish(alice.commitments).or(Err(()))?;
-//! let (bob_group_key, bob_secret_key) = bob_state.finish(bob.commitments).or(Err(()))?;
-//! let (carol_group_key, carol_secret_key) = carol_state.finish(carol.commitments).or(Err(()))?;
+//! let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
+//! let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
+//! let (carol_group_key, carol_secret_key) = carol_state.finish().or(Err(()))?;
 //!
 //! assert!(alice_group_key == bob_group_key);
 //! assert!(carol_group_key == bob_group_key);
@@ -433,38 +442,41 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut alice_other_participants: Vec<Participant> = vec!(bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut alice_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut bob_other_participants: Vec<Participant> = vec!(alice.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut bob_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut carol_other_participants: Vec<Participant> = vec!(alice.clone(), bob.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut carol_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec!(bob_their_encrypted_secret_shares[0].clone(),
+//! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
-//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
+//! #                                 bob_their_encrypted_secret_shares[1].clone(),
 //! #                                 carol_their_encrypted_secret_shares[1].clone());
-//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
-//! #                                   bob_their_encrypted_secret_shares[1].clone());
+//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[2].clone(),
+//! #                                   bob_their_encrypted_secret_shares[2].clone(),
+//! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
 //! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
 //! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
 //! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
 //! #
-//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.commitments).or(Err(()))?;
-//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.commitments).or(Err(()))?;
-//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.commitments).or(Err(()))?;
+//! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
+//! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
+//! # let (carol_group_key, carol_secret_key) = carol_state.finish().or(Err(()))?;
 //! #
 //! # let alice_public_key = alice_secret_key.to_public();
 //! # let bob_public_key = bob_secret_key.to_public();
@@ -508,38 +520,41 @@
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut alice_other_participants: Vec<Participant> = vec!(bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut alice_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut bob_other_participants: Vec<Participant> = vec!(alice.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut bob_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &mut participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut carol_other_participants: Vec<Participant> = vec!(alice.clone(), bob.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut carol_other_participants, "Φ").or(Err(()))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
-//! # let alice_my_encrypted_secret_shares = vec!(bob_their_encrypted_secret_shares[0].clone(),
+//! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
-//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
+//! #                                 bob_their_encrypted_secret_shares[1].clone(),
 //! #                                 carol_their_encrypted_secret_shares[1].clone());
-//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
-//! #                                   bob_their_encrypted_secret_shares[1].clone());
+//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[2].clone(),
+//! #                                   bob_their_encrypted_secret_shares[2].clone(),
+//! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
 //! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
 //! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
 //! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
 //! #
-//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.commitments).or(Err(()))?;
-//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.commitments).or(Err(()))?;
-//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.commitments).or(Err(()))?;
+//! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
+//! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
+//! # let (carol_group_key, carol_secret_key) = carol_state.finish().or(Err(()))?;
 //! #
 //! # let alice_public_key = alice_secret_key.to_public();
 //! # let bob_public_key = bob_secret_key.to_public();
@@ -586,38 +601,41 @@
 //! # fn do_test() -> Result<(), &'static str> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut alice_other_participants: Vec<Participant> = vec!(bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut alice_other_participants, "Φ").or(Err(""))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let alice_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(""))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(""))?;
 //! #
-//! # let mut bob_other_participants: Vec<Participant> = vec!(alice.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut bob_other_participants, "Φ").or(Err(""))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let bob_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &mut participants, "Φ").or(Err(""))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(""))?;
 //! #
-//! # let mut carol_other_participants: Vec<Participant> = vec!(alice.clone(), bob.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut carol_other_participants, "Φ").or(Err(""))?;
+//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let carol_state = DistributedKeyGeneration::<_>::new_initial_state(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &mut participants, "Φ").or(Err(""))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(""))?;
-//! # let alice_my_encrypted_secret_shares = vec!(bob_their_encrypted_secret_shares[0].clone(),
+//! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
-//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
+//! # let bob_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
+//! #                                 bob_their_encrypted_secret_shares[1].clone(),
 //! #                                 carol_their_encrypted_secret_shares[1].clone());
-//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[1].clone(),
-//! #                                   bob_their_encrypted_secret_shares[1].clone());
+//! # let carol_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[2].clone(),
+//! #                                   bob_their_encrypted_secret_shares[2].clone(),
+//! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
 //! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(""))?;
 //! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(""))?;
 //! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(""))?;
 //! #
-//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.commitments).or(Err(""))?;
-//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.commitments).or(Err(""))?;
-//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.commitments).or(Err(""))?;
+//! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(""))?;
+//! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(""))?;
+//! # let (carol_group_key, carol_secret_key) = carol_state.finish().or(Err(""))?;
 //! #
 //! # let alice_public_key = alice_secret_key.to_public();
 //! # let bob_public_key = bob_secret_key.to_public();
@@ -682,12 +700,8 @@
 //! ```rust,ignore
 //! let verified = threshold_signature.verify(&alice_group_key, &message_hash)?;
 //! ```
-//!
-//! # Note on `no_std` usage
-//!
-//! Most of this crate is `no_std` compliant, however, the current
-//! implementation uses `HashMap`s for the signature creation and aggregation
-//! protocols, and thus requires the standard library.
+
+// TODO: update examples with different configurations
 
 #![no_std]
 #![warn(future_incompatible)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@
 //! #
 //! # let params = Parameters { t: 2, n: 3 };
 //! 
+//! // Each application developer should choose a context string as unique to their usage
+//! // as possible (instead of the below "Φ"), in order to prevent replay attacks.
 //! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
@@ -98,7 +100,8 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! alice.proof_of_secret_key.as_ref().unwrap().verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
+//! alice.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -117,7 +120,8 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! bob.proof_of_secret_key.as_ref().unwrap().verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
+//! bob.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -136,7 +140,8 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! carol.proof_of_secret_key.as_ref().unwrap().verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
+//! carol.proof_of_secret_key.as_ref().unwrap()
+//!     .verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -144,22 +149,30 @@
 //!
 //! ```rust
 //! use ice_frost::DistributedKeyGeneration;
+//! # use ice_frost::Error;
 //! # use ice_frost::Parameters;
 //! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
 //! #
-//! # fn do_test() -> Result<(), Vec<u32>> {
+//! # fn do_test() -> Result<(), Error> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
 //! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //!
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//!                                                      &mut participants, "Φ")?;
+//! let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! let (alice_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &alice_dh_sk,
+//!         &alice.index,
+//!         &alice_coefficients,
+//!         &participants,
+//!         "Φ",
+//!     )?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -180,9 +193,9 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //!
 //! // send_to_bob(alice_their_encrypted_secret_shares[0]);
@@ -194,22 +207,30 @@
 //!
 //! ```rust
 //! # use ice_frost::DistributedKeyGeneration;
+//! # use ice_frost::Error;
 //! # use ice_frost::Parameters;
 //! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
 //! #
-//! # fn do_test() -> Result<(), Vec<u32>> {
+//! # fn do_test() -> Result<(), Error> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
 //! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//!                                                    &mut participants, "Φ")?;
+//! let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! let (bob_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &bob_dh_sk,
+//!         &bob.index,
+//!         &bob_coefficients,
+//!         &participants,
+//!         "Φ",
+//!     )?;
 //! # Ok(()) }
 //! # fn do_test2() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
@@ -218,9 +239,9 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //!
 //! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //!
@@ -233,22 +254,30 @@
 //!
 //! ```rust
 //! # use ice_frost::DistributedKeyGeneration;
+//! # use ice_frost::Error;
 //! # use ice_frost::Parameters;
 //! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
 //! #
-//! # fn do_test() -> Result<(), Vec<u32>> {
+//! # fn do_test() -> Result<(), Error> {
 //! # let params = Parameters { t: 2, n: 3 };
 //! #
 //! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//!                                                      &mut participants, "Φ")?;
+//! let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! let (carol_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new_initial(
+//!         &params,
+//!         &carol_dh_sk,
+//!         &carol.index,
+//!         &carol_coefficients,
+//!         &participants,
+//!         "Φ",
+//!     )?;
 //! # Ok(()) }
 //! # fn do_test2() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
@@ -257,9 +286,9 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //!
 //! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //!
@@ -285,19 +314,17 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //!                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -329,19 +356,17 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -378,19 +403,17 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -427,9 +450,9 @@
 //! Claire and David, to sign with respect to the same group's public key.
 //!
 //! ```rust
-//! # use frost_dalek::DistributedKeyGeneration;
-//! # use frost_dalek::Parameters;
-//! # use frost_dalek::Participant;
+//! # use ice_frost::DistributedKeyGeneration;
+//! # use ice_frost::Parameters;
+//! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
@@ -443,19 +466,17 @@
 //! 
 //! // Perform regular 2-out-of-3 DKG...
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -486,17 +507,16 @@
 //! let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
 //! let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
 //! 
-//! let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! let (alice_as_dealer, alice_encrypted_shares) =
-//!     Participant::reshare(&new_params, alice_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! let signers: Vec<Participant> =
+//!     vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
+//! let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
+//!     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
 //! 
-//! let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! let (bob_as_dealer, bob_encrypted_shares) =
-//!     Participant::reshare(&new_params, bob_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
+//!     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
 //! 
-//! let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! let (carol_as_dealer, carol_encrypted_shares) =
-//!     Participant::reshare(&new_params, carol_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
+//!     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -504,9 +524,9 @@
 //! generation protocol with respect to the previous set of dealers.
 //!
 //! ```rust
-//! # use frost_dalek::DistributedKeyGeneration;
-//! # use frost_dalek::Parameters;
-//! # use frost_dalek::Participant;
+//! # use ice_frost::DistributedKeyGeneration;
+//! # use ice_frost::Parameters;
+//! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
@@ -518,19 +538,17 @@
 //! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -561,31 +579,55 @@
 //! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
 //! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
 //! #
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (alice_as_dealer, alice_encrypted_shares) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &mut signers, "Φ").or(Err(()))?;
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (bob_as_dealer, bob_encrypted_shares) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &mut signers, "Φ").or(Err(()))?;
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (carol_as_dealer, carol_encrypted_shares) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! # let signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
+//! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
+//! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
+//! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
 //! #
-//! let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! let alexis_state = DistributedKeyGeneration::<_>::new(&params, &alexis_dh_sk, &alexis.index,
-//!                                                    &mut dealers, "Φ").or(Err(()))?;
+//! let dealers: Vec<Participant> =
+//!     vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
+//! let (alexis_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new(
+//!         &params,
+//!         &alexis_dh_sk,
+//!         &alexis.index,
+//!         &dealers,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //! 
-//! let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! let barbara_state = DistributedKeyGeneration::<_>::new(&params, &barbara_dh_sk, &barbara.index,
-//!                                                    &mut dealers, "Φ").or(Err(()))?;
+//! let (barbara_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new(
+//!         &params,
+//!         &barbara_dh_sk,
+//!         &barbara.index,
+//!         &dealers,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //! 
-//! let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! let claire_state = DistributedKeyGeneration::<_>::new(&params, &claire_dh_sk, &claire.index,
-//!                                                      &mut dealers, "Φ").or(Err(()))?;
+//! let (claire_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new(
+//!         &params,
+//!         &claire_dh_sk,
+//!         &claire.index,
+//!         &dealers,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //! 
-//! let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! let david_state = DistributedKeyGeneration::<_>::new(&params, &david_dh_sk, &david.index,
-//!                                                      &mut dealers, "Φ").or(Err(()))?;
+//! let (david_state, participant_lists) =
+//!     DistributedKeyGeneration::<_>::new(
+//!         &params,
+//!         &david_dh_sk,
+//!         &david.index,
+//!         &dealers,
+//!         "Φ",
+//!     )
+//!     .or(Err(()))?;
 //! #
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
@@ -595,9 +637,9 @@
 //! distributed key resharing protocol.
 //!
 //! ```rust
-//! # use frost_dalek::DistributedKeyGeneration;
-//! # use frost_dalek::Parameters;
-//! # use frost_dalek::Participant;
+//! # use ice_frost::DistributedKeyGeneration;
+//! # use ice_frost::Parameters;
+//! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
@@ -609,19 +651,17 @@
 //! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -652,31 +692,27 @@
 //! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
 //! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
 //! #
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (alice_as_dealer, alice_encrypted_shares) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &mut signers, "Φ").or(Err(()))?;
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (bob_as_dealer, bob_encrypted_shares) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &mut signers, "Φ").or(Err(()))?;
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (carol_as_dealer, carol_encrypted_shares) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! # let signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
+//! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
+//! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
+//! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
 //! #
-//! # let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! # let alexis_state = DistributedKeyGeneration::<_>::new(&params, &alexis_dh_sk, &alexis.index,
-//! #                                                    &mut dealers, "Φ").or(Err(()))?;
+//! # let dealers: Vec<Participant> =
+//! #     vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
+//! # let (alexis_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &alexis_dh_sk, &alexis.index,
+//! #                                                    &dealers, "Φ").or(Err(()))?;
 //! #
-//! # let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! # let barbara_state = DistributedKeyGeneration::<_>::new(&params, &barbara_dh_sk, &barbara.index,
-//! #                                                    &mut dealers, "Φ").or(Err(()))?;
+//! # let (barbara_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &barbara_dh_sk, &barbara.index,
+//! #                                                    &dealers, "Φ").or(Err(()))?;
 //! #
-//! # let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! # let claire_state = DistributedKeyGeneration::<_>::new(&params, &claire_dh_sk, &claire.index,
-//! #                                                      &mut dealers, "Φ").or(Err(()))?;
+//! # let (claire_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &claire_dh_sk, &claire.index,
+//! #                                                      &dealers, "Φ").or(Err(()))?;
 //! #
-//! # let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! # let david_state = DistributedKeyGeneration::<_>::new(&params, &david_dh_sk, &david.index,
-//! #                                                      &mut dealers, "Φ").or(Err(()))?;
+//! # let (david_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &david_dh_sk, &david.index,
+//! #                                                      &dealers, "Φ").or(Err(()))?;
 //! #
 //! # let alexis_my_encrypted_secret_shares = vec!(alice_encrypted_shares[0].clone(),
 //! #                                   bob_encrypted_shares[0].clone(),
@@ -703,9 +739,9 @@
 //! and obtain their own long-lived, personal secret keys.
 //!
 //! ```rust
-//! # use frost_dalek::DistributedKeyGeneration;
-//! # use frost_dalek::Parameters;
-//! # use frost_dalek::Participant;
+//! # use ice_frost::DistributedKeyGeneration;
+//! # use ice_frost::Parameters;
+//! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
@@ -717,19 +753,17 @@
 //! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -759,31 +793,26 @@
 //! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
 //! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
 //! #
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (alice_as_dealer, alice_encrypted_shares) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &mut signers, "Φ").or(Err(()))?;
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (bob_as_dealer, bob_encrypted_shares) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &mut signers, "Φ").or(Err(()))?;
-//! # let mut signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
-//! # let (carol_as_dealer, carol_encrypted_shares) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &mut signers, "Φ").or(Err(()))?;
+//! # let signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
+//! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
+//! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
+//! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
+//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
 //! #
-//! # let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! # let alexis_state = DistributedKeyGeneration::<_>::new(&params, &alexis_dh_sk, &alexis.index,
-//! #                                                    &mut dealers, "Φ").or(Err(()))?;
+//! # let dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
+//! # let (alexis_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &alexis_dh_sk, &alexis.index,
+//! #                                                    &dealers, "Φ").or(Err(()))?;
 //! #
-//! # let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! # let barbara_state = DistributedKeyGeneration::<_>::new(&params, &barbara_dh_sk, &barbara.index,
-//! #                                                    &mut dealers, "Φ").or(Err(()))?;
+//! # let (barbara_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &barbara_dh_sk, &barbara.index,
+//! #                                                    &dealers, "Φ").or(Err(()))?;
 //! #
-//! # let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! # let claire_state = DistributedKeyGeneration::<_>::new(&params, &claire_dh_sk, &claire.index,
-//! #                                                      &mut dealers, "Φ").or(Err(()))?;
+//! # let (claire_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &claire_dh_sk, &claire.index,
+//! #                                                      &dealers, "Φ").or(Err(()))?;
 //! #
-//! # let mut dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
-//! # let david_state = DistributedKeyGeneration::<_>::new(&params, &david_dh_sk, &david.index,
-//! #                                                      &mut dealers, "Φ").or(Err(()))?;
+//! # let (david_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &david_dh_sk, &david.index,
+//! #                                                      &dealers, "Φ").or(Err(()))?;
 //! #
 //! # let alexis_my_encrypted_secret_shares = vec!(alice_encrypted_shares[0].clone(),
 //! #                                   bob_encrypted_shares[0].clone(),
@@ -842,19 +871,17 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -878,12 +905,16 @@
 //! # let bob_public_key = bob_secret_key.to_public();
 //! # let carol_public_key = carol_secret_key.to_public();
 //!
-//! let (alice_public_comshares, mut alice_secret_comshares) = generate_commitment_share_lists(&mut OsRng, 1, 1);
-//! let (bob_public_comshares, mut bob_secret_comshares) = generate_commitment_share_lists(&mut OsRng, 2, 1);
-//! let (carol_public_comshares, mut carol_secret_comshares) = generate_commitment_share_lists(&mut OsRng, 3, 1);
+//! let (alice_public_comshares, mut alice_secret_comshares) =
+//!     generate_commitment_share_lists(&mut OsRng, 1, 1);
+//! let (bob_public_comshares, mut bob_secret_comshares) =
+//!     generate_commitment_share_lists(&mut OsRng, 2, 1);
+//! let (carol_public_comshares, mut carol_secret_comshares) =
+//!     generate_commitment_share_lists(&mut OsRng, 3, 1);
 //!
-//! // Each application developer should choose a context string as unique to their usage as possible,
-//! // in order to provide domain separation from other applications which use FROST signatures.
+//! // Each application developer should choose a context string as unique
+//! // to their usage as possible, in order to provide domain separation
+//! // from other applications which use FROST signatures.
 //! let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
 //! let message = b"This is a test of the tsunami alert system. This is only a test.";
 //!
@@ -891,7 +922,13 @@
 //! // some additional context, such as public information about the run of the protocol.
 //! let message_hash = compute_message_hash(&context[..], &message[..]);
 //!
-//! let mut aggregator = SignatureAggregator::new(params, bob_group_key.clone(), &context[..], &message[..]);
+//! let mut aggregator =
+//!     SignatureAggregator::new(
+//!         params,
+//!         bob_group_key.clone(),
+//!         &context[..],
+//!         &message[..],
+//!     );
 //! # Ok(()) }
 //! # fn main() { assert!(do_test().is_ok()); }
 //! ```
@@ -920,19 +957,17 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(()))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(()))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(()))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(()))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -1001,19 +1036,17 @@
 //! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 //! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let alice_state = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(""))?;
+//! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
+//! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
+//! #                                                      &participants, "Φ").or(Err(""))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(""))?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let bob_state = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &mut participants, "Φ").or(Err(""))?;
+//! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
+//! #                                                    &participants, "Φ").or(Err(""))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(""))?;
 //! #
-//! # let mut participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
-//! # let carol_state = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &mut participants, "Φ").or(Err(""))?;
+//! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
+//! #                                                      &participants, "Φ").or(Err(""))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(""))?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -1118,6 +1151,8 @@ pub mod parameters;
 pub mod precomputation;
 pub mod nizk;
 pub mod signature;
+
+pub use keygen::Error;
 
 pub use keygen::DistributedKeyGeneration;
 pub use keygen::GroupKey;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,9 +397,9 @@
 //! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
 //! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
 //! #
-//! let (alice_group_key, alice_secret_key) = alice_state.finish(alice.public_key().unwrap()).or(Err(()))?;
-//! let (bob_group_key, bob_secret_key) = bob_state.finish(bob.public_key().unwrap()).or(Err(()))?;
-//! let (carol_group_key, carol_secret_key) = carol_state.finish(carol.public_key().unwrap()).or(Err(()))?;
+//! let (alice_group_key, alice_secret_key) = alice_state.finish(alice.commitments).or(Err(()))?;
+//! let (bob_group_key, bob_secret_key) = bob_state.finish(bob.commitments).or(Err(()))?;
+//! let (carol_group_key, carol_secret_key) = carol_state.finish(carol.commitments).or(Err(()))?;
 //!
 //! assert!(alice_group_key == bob_group_key);
 //! assert!(carol_group_key == bob_group_key);
@@ -462,9 +462,9 @@
 //! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
 //! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
 //! #
-//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.public_key().unwrap()).or(Err(()))?;
-//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.public_key().unwrap()).or(Err(()))?;
-//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.public_key().unwrap()).or(Err(()))?;
+//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.commitments).or(Err(()))?;
+//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.commitments).or(Err(()))?;
+//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.commitments).or(Err(()))?;
 //! #
 //! # let alice_public_key = alice_secret_key.to_public();
 //! # let bob_public_key = bob_secret_key.to_public();
@@ -537,9 +537,9 @@
 //! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
 //! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
 //! #
-//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.public_key().unwrap()).or(Err(()))?;
-//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.public_key().unwrap()).or(Err(()))?;
-//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.public_key().unwrap()).or(Err(()))?;
+//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.commitments).or(Err(()))?;
+//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.commitments).or(Err(()))?;
+//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.commitments).or(Err(()))?;
 //! #
 //! # let alice_public_key = alice_secret_key.to_public();
 //! # let bob_public_key = bob_secret_key.to_public();
@@ -615,9 +615,9 @@
 //! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(""))?;
 //! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(""))?;
 //! #
-//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.public_key().unwrap()).or(Err(""))?;
-//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.public_key().unwrap()).or(Err(""))?;
-//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.public_key().unwrap()).or(Err(""))?;
+//! # let (alice_group_key, alice_secret_key) = alice_state.finish(alice.commitments).or(Err(""))?;
+//! # let (bob_group_key, bob_secret_key) = bob_state.finish(bob.commitments).or(Err(""))?;
+//! # let (carol_group_key, carol_secret_key) = carol_state.finish(carol.commitments).or(Err(""))?;
 //! #
 //! # let alice_public_key = alice_secret_key.to_public();
 //! # let bob_public_key = bob_secret_key.to_public();

--- a/src/nizk.rs
+++ b/src/nizk.rs
@@ -28,7 +28,7 @@ use sha2::Sha512;
 ///
 /// This proof is created by making a pseudo-Schnorr signature,
 /// \\( \sigma\_i = (s\_i, r\_i) \\) using \\( a\_{i0} \\) (from
-/// `frost_dalek::keygen::DistributedKeyGeneration::<RoundOne>::compute_share`)
+/// `ice_frost::keygen::DistributedKeyGeneration::<RoundOne>::compute_share`)
 /// as the secret key, such that \\( k \stackrel{\\$}{\leftarrow} \mathbb{Z}\_q \\),
 /// \\( M\_i = g^k \\), \\( s\_i = \mathcal{H}(i, \phi, g^{a\_{i0}}, M\_i) \\),
 /// \\( r\_i = k + a\_{i0} \cdot s\_i \\).

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -705,7 +705,7 @@ mod test {
     fn signing_and_verification_single_party() {
         let params = Parameters { n: 1, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
@@ -713,7 +713,7 @@ mod test {
         let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
-                                                                 &p1coeffs,
+                                                                 &p1coeffs.unwrap(),
                                                                  &mut p1_other_participants,
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = Vec::new();
@@ -756,13 +756,13 @@ mod test {
     fn signing_and_verification_1_out_of_1() {
         let params = Parameters { n: 1, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
 
         let mut p1_other_participants: Vec<Participant> = Vec::with_capacity(0);
         let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
-                                                                 &p1coeffs,
+                                                                 &p1coeffs.unwrap(),
                                                                  &mut p1_other_participants,
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = Vec::with_capacity(0);
@@ -796,14 +796,14 @@ mod test {
     fn signing_and_verification_1_out_of_2() {
         let params = Parameters { n: 2, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
 
         let mut p1_other_participants: Vec<Participant> = vec!(p2.clone());
         let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
-                                                                 &p1coeffs,
+                                                                 &p1coeffs.unwrap(),
                                                                  &mut p1_other_participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
@@ -812,7 +812,7 @@ mod test {
         let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
-                                                                 &p2coeffs,
+                                                                 &p2coeffs.unwrap(),
                                                                  &mut p2_other_participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
@@ -852,17 +852,17 @@ mod test {
     fn signing_and_verification_3_out_of_5() {
         let params = Parameters { n: 5, t: 3 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
-        let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
-        let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, None, "Φ");
-        let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, None, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
+        let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
+        let (p4, p4coeffs, p4_dh_sk) = Participant::new(&params, false, 4, None, "Φ");
+        let (p5, p5coeffs, p5_dh_sk) = Participant::new(&params, false, 5, None, "Φ");
 
         let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone(), p4.clone(), p5.clone());
         let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
-                                                                 &p1coeffs,
+                                                                 &p1coeffs.unwrap(),
                                                                  &mut p1_other_participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
@@ -871,7 +871,7 @@ mod test {
         let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
-                                                                 &p2coeffs,
+                                                                 &p2coeffs.unwrap(),
                                                                  &mut p2_other_participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
@@ -880,7 +880,7 @@ mod test {
         let p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p3_dh_sk,
                                                                  &p3.index,
-                                                                 &p3coeffs,
+                                                                 &p3coeffs.unwrap(),
                                                                  &mut p3_other_participants,
                                                                  "Φ").unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
@@ -889,7 +889,7 @@ mod test {
         let p4_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
-                                                                 &p4coeffs,
+                                                                 &p4coeffs.unwrap(),
                                                                  &mut p4_other_participants,
                                                                  "Φ").unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
@@ -898,7 +898,7 @@ mod test {
         let p5_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
-                                                                 &p5coeffs,
+                                                                 &p5coeffs.unwrap(),
                                                                  &mut p5_other_participants,
                                                                  "Φ").unwrap();
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
@@ -975,9 +975,9 @@ mod test {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
 
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
@@ -986,7 +986,7 @@ mod test {
             let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
-                                                                     &p1coeffs,
+                                                                     &p1coeffs.unwrap(),
                                                                      &mut p1_other_participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
@@ -995,7 +995,7 @@ mod test {
             let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
-                                                                     &p2coeffs,
+                                                                     &p2coeffs.unwrap(),
                                                                      &mut p2_other_participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
@@ -1004,7 +1004,7 @@ mod test {
             let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
-                                                                      &p3coeffs,
+                                                                      &p3coeffs.unwrap(),
                                                                       &mut p3_other_participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
@@ -1108,9 +1108,9 @@ mod test {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
 
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
@@ -1119,7 +1119,7 @@ mod test {
             let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
-                                                                     &p1coeffs,
+                                                                     &p1coeffs.unwrap(),
                                                                      &mut p1_other_participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
@@ -1128,7 +1128,7 @@ mod test {
             let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
-                                                                     &p2coeffs,
+                                                                     &p2coeffs.unwrap(),
                                                                      &mut p2_other_participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
@@ -1137,7 +1137,7 @@ mod test {
             let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
-                                                                      &p3coeffs,
+                                                                      &p3coeffs.unwrap(),
                                                                       &mut p3_other_participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -705,12 +705,12 @@ mod test {
     fn signing_and_verification_single_party() {
         let params = Parameters { n: 1, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, 1, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
 
-        p1.proof_of_secret_key.verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
+        p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
         let mut p1_other_participants: Vec<Participant> = Vec::new();
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -718,7 +718,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = Vec::new();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
-        let result = p1_state.finish(p1.commitments.points);
+        let result = p1_state.finish(p1.commitments.unwrap().points);
 
         assert!(result.is_ok());
 
@@ -756,10 +756,10 @@ mod test {
     fn signing_and_verification_1_out_of_1() {
         let params = Parameters { n: 1, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, 1, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
 
         let mut p1_other_participants: Vec<Participant> = Vec::with_capacity(0);
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -768,7 +768,7 @@ mod test {
         let p1_my_encrypted_secret_shares = Vec::with_capacity(0);
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
+        let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -796,11 +796,11 @@ mod test {
     fn signing_and_verification_1_out_of_2() {
         let params = Parameters { n: 2, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, 1, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, 2, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
 
         let mut p1_other_participants: Vec<Participant> = vec!(p2.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -809,7 +809,7 @@ mod test {
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
         let mut p2_other_participants: Vec<Participant> = vec!(p1.clone());
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs,
@@ -823,8 +823,8 @@ mod test {
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
         let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
-        let (_, _p2_sk) = p2_state.finish(p2.commitments.points).unwrap();
+        let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
+        let (_, _p2_sk) = p2_state.finish(p2.commitments.unwrap().points).unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -852,14 +852,14 @@ mod test {
     fn signing_and_verification_3_out_of_5() {
         let params = Parameters { n: 5, t: 3 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, 1, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, 2, "Φ");
-        let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, 3, "Φ");
-        let (p4, p4coeffs, p4_dh_sk) = Participant::new(&params, 4, "Φ");
-        let (p5, p5coeffs, p5_dh_sk) = Participant::new(&params, 5, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
+        let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
+        let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, None, "Φ");
+        let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, None, "Φ");
 
         let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -868,7 +868,7 @@ mod test {
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
         let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs,
@@ -877,7 +877,7 @@ mod test {
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
         let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p4.clone(), p5.clone());
-        let p3_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p3_dh_sk,
                                                                  &p3.index,
                                                                  &p3coeffs,
@@ -886,7 +886,7 @@ mod test {
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
         let mut p4_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p5.clone());
-        let p4_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p4_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
                                                                  &p4coeffs,
@@ -895,7 +895,7 @@ mod test {
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
         let mut p5_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone());
-        let p5_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+        let p5_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
                                                                  &p5coeffs,
@@ -934,11 +934,11 @@ mod test {
         let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
         let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
-        let (_, _) = p2_state.finish(p2.commitments.points).unwrap();
-        let (_, p3_sk) = p3_state.finish(p3.commitments.points).unwrap();
-        let (_, p4_sk) = p4_state.finish(p4.commitments.points).unwrap();
-        let (_, _) = p5_state.finish(p5.commitments.points).unwrap();
+        let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
+        let (_, _) = p2_state.finish(p2.commitments.unwrap().points).unwrap();
+        let (_, p3_sk) = p3_state.finish(p3.commitments.unwrap().points).unwrap();
+        let (_, p4_sk) = p4_state.finish(p4.commitments.unwrap().points).unwrap();
+        let (_, _) = p5_state.finish(p5.commitments.unwrap().points).unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -975,15 +975,15 @@ mod test {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, 1, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, 2, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, 3, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
 
-            p2.proof_of_secret_key.verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
-            p3.proof_of_secret_key.verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
+            p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
+            p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
 
             let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -992,7 +992,7 @@ mod test {
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
             let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -1001,7 +1001,7 @@ mod test {
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
             let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
@@ -1020,9 +1020,9 @@ mod test {
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
             let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
 
-            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.commitments.points).or(Err(()))?;
-            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.commitments.points).or(Err(()))?;
-            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.commitments.points).or(Err(()))?;
+            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.commitments.unwrap().points).or(Err(()))?;
+            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.commitments.unwrap().points).or(Err(()))?;
+            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.commitments.unwrap().points).or(Err(()))?;
 
             assert!(p1_group_key.0.compress() == p2_group_key.0.compress());
             assert!(p2_group_key.0.compress() == p3_group_key.0.compress());
@@ -1108,15 +1108,15 @@ mod test {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, 1, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, 2, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, 3, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
 
-            p2.proof_of_secret_key.verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
-            p3.proof_of_secret_key.verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
+            p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
+            p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
 
             let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -1125,7 +1125,7 @@ mod test {
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
             let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -1134,7 +1134,7 @@ mod test {
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
             let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
@@ -1153,9 +1153,9 @@ mod test {
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
             let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
 
-            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.commitments.points).or(Err(()))?;
-            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.commitments.points).or(Err(()))?;
-            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.commitments.points).or(Err(()))?;
+            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.commitments.unwrap().points).or(Err(()))?;
+            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.commitments.unwrap().points).or(Err(()))?;
+            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.commitments.unwrap().points).or(Err(()))?;
 
             assert!(p1_group_key.0.compress() == p2_group_key.0.compress());
             assert!(p2_group_key.0.compress() == p3_group_key.0.compress());

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -705,7 +705,7 @@ mod test {
     fn signing_and_verification_single_party() {
         let params = Parameters { n: 1, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
@@ -713,7 +713,7 @@ mod test {
         let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
-                                                                 &p1coeffs.unwrap(),
+                                                                 &p1coeffs,
                                                                  &mut participants,
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
@@ -756,13 +756,13 @@ mod test {
     fn signing_and_verification_1_out_of_1() {
         let params = Parameters { n: 1, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
 
         let mut participants: Vec<Participant> = vec![p1.clone()];
         let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
-                                                                 &p1coeffs.unwrap(),
+                                                                 &p1coeffs,
                                                                  &mut participants,
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
@@ -796,14 +796,14 @@ mod test {
     fn signing_and_verification_1_out_of_2() {
         let params = Parameters { n: 2, t: 1 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 
         let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
         let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
-                                                                 &p1coeffs.unwrap(),
+                                                                 &p1coeffs,
                                                                  &mut participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
@@ -811,7 +811,7 @@ mod test {
         let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
-                                                                 &p2coeffs.unwrap(),
+                                                                 &p2coeffs,
                                                                  &mut participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
@@ -853,17 +853,17 @@ mod test {
     fn signing_and_verification_3_out_of_5() {
         let params = Parameters { n: 5, t: 3 };
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
-        let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
-        let (p4, p4coeffs, p4_dh_sk) = Participant::new(&params, false, 4, None, "Φ");
-        let (p5, p5coeffs, p5_dh_sk) = Participant::new(&params, false, 5, None, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+        let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+        let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ");
+        let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
 
         let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
         let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
-                                                                 &p1coeffs.unwrap(),
+                                                                 &p1coeffs,
                                                                  &mut participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
@@ -871,7 +871,7 @@ mod test {
         let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
-                                                                 &p2coeffs.unwrap(),
+                                                                 &p2coeffs,
                                                                  &mut participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
@@ -879,7 +879,7 @@ mod test {
         let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                   &p3_dh_sk,
                                                                   &p3.index,
-                                                                  &p3coeffs.unwrap(),
+                                                                  &p3coeffs,
                                                                   &mut participants,
                                                                   "Φ").unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
@@ -887,7 +887,7 @@ mod test {
         let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
-                                                                 &p4coeffs.unwrap(),
+                                                                 &p4coeffs,
                                                                  &mut participants,
                                                                  "Φ").unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
@@ -895,7 +895,7 @@ mod test {
         let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
-                                                                 &p5coeffs.unwrap(),
+                                                                 &p5coeffs,
                                                                  &mut participants,
                                                                  "Φ").unwrap();
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
@@ -977,9 +977,9 @@ mod test {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
@@ -988,7 +988,7 @@ mod test {
             let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
-                                                                     &p1coeffs.unwrap(),
+                                                                     &p1coeffs,
                                                                      &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
@@ -996,7 +996,7 @@ mod test {
             let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
-                                                                     &p2coeffs.unwrap(),
+                                                                     &p2coeffs,
                                                                      &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
@@ -1004,7 +1004,7 @@ mod test {
             let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
-                                                                      &p3coeffs.unwrap(),
+                                                                      &p3coeffs,
                                                                       &mut participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
@@ -1111,46 +1111,47 @@ mod test {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
 
-            let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
-                                                                     &p1coeffs.unwrap(),
-                                                                     &mut p1_other_participants,
+                                                                     &p1coeffs,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
-                                                                     &p2coeffs.unwrap(),
-                                                                     &mut p2_other_participants,
+                                                                     &p2coeffs,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
-                                                                      &p3coeffs.unwrap(),
-                                                                      &mut p3_other_participants,
+                                                                      &p3coeffs,
+                                                                      &mut participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
-            let p1_my_encrypted_secret_shares = vec!(p2_their_encrypted_secret_shares[0].clone(), // XXX FIXME indexing
+            let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+                                           p2_their_encrypted_secret_shares[0].clone(),
                                            p3_their_encrypted_secret_shares[0].clone());
-            let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+            let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
+                                           p2_their_encrypted_secret_shares[1].clone(),
                                            p3_their_encrypted_secret_shares[1].clone());
-            let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
-                                           p2_their_encrypted_secret_shares[1].clone());
+            let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
+                                           p2_their_encrypted_secret_shares[2].clone(),
+                                           p3_their_encrypted_secret_shares[2].clone());
 
             let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -718,7 +718,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = Vec::new();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
-        let result = p1_state.finish(p1.public_key().unwrap());
+        let result = p1_state.finish(p1.commitments.points);
 
         assert!(result.is_ok());
 
@@ -768,7 +768,7 @@ mod test {
         let p1_my_encrypted_secret_shares = Vec::with_capacity(0);
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.public_key().unwrap()).unwrap();
+        let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -823,8 +823,8 @@ mod test {
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
         let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.public_key().unwrap()).unwrap();
-        let (_, _p2_sk) = p2_state.finish(p2.public_key().unwrap()).unwrap();
+        let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
+        let (_, _p2_sk) = p2_state.finish(p2.commitments.points).unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -934,11 +934,11 @@ mod test {
         let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
         let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.public_key().unwrap()).unwrap();
-        let (_, _) = p2_state.finish(p2.public_key().unwrap()).unwrap();
-        let (_, p3_sk) = p3_state.finish(p3.public_key().unwrap()).unwrap();
-        let (_, p4_sk) = p4_state.finish(p4.public_key().unwrap()).unwrap();
-        let (_, _) = p5_state.finish(p5.public_key().unwrap()).unwrap();
+        let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
+        let (_, _) = p2_state.finish(p2.commitments.points).unwrap();
+        let (_, p3_sk) = p3_state.finish(p3.commitments.points).unwrap();
+        let (_, p4_sk) = p4_state.finish(p4.commitments.points).unwrap();
+        let (_, _) = p5_state.finish(p5.commitments.points).unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -1020,9 +1020,9 @@ mod test {
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
             let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
 
-            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.public_key().unwrap()).or(Err(()))?;
-            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.public_key().unwrap()).or(Err(()))?;
-            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.public_key().unwrap()).or(Err(()))?;
+            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.commitments.points).or(Err(()))?;
+            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.commitments.points).or(Err(()))?;
+            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.commitments.points).or(Err(()))?;
 
             assert!(p1_group_key.0.compress() == p2_group_key.0.compress());
             assert!(p2_group_key.0.compress() == p3_group_key.0.compress());
@@ -1153,9 +1153,9 @@ mod test {
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
             let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
 
-            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.public_key().unwrap()).or(Err(()))?;
-            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.public_key().unwrap()).or(Err(()))?;
-            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.public_key().unwrap()).or(Err(()))?;
+            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.commitments.points).or(Err(()))?;
+            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.commitments.points).or(Err(()))?;
+            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.commitments.points).or(Err(()))?;
 
             assert!(p1_group_key.0.compress() == p2_group_key.0.compress());
             assert!(p2_group_key.0.compress() == p3_group_key.0.compress());

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -709,14 +709,14 @@ mod test {
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
-        let mut p1_other_participants: Vec<Participant> = Vec::new();
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let mut participants: Vec<Participant> = vec![p1.clone()];
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs.unwrap(),
-                                                                 &mut p1_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
-        let p1_my_encrypted_secret_shares = Vec::new();
+        let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
         let result = p1_state.finish();
 
@@ -758,14 +758,14 @@ mod test {
 
         let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
 
-        let mut p1_other_participants: Vec<Participant> = Vec::with_capacity(0);
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let mut participants: Vec<Participant> = vec![p1.clone()];
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs.unwrap(),
-                                                                 &mut p1_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
-        let p1_my_encrypted_secret_shares = Vec::with_capacity(0);
+        let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
 
         let (group_key, p1_sk) = p1_state.finish().unwrap();
@@ -799,26 +799,27 @@ mod test {
         let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
         let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
 
-        let mut p1_other_participants: Vec<Participant> = vec!(p2.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs.unwrap(),
-                                                                 &mut p1_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let mut p2_other_participants: Vec<Participant> = vec!(p1.clone());
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs.unwrap(),
-                                                                 &mut p2_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-        let p1_my_encrypted_secret_shares = vec!(p2_their_encrypted_secret_shares[0].clone()); // XXX FIXME indexing
-        let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone());
+        let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+                                               p2_their_encrypted_secret_shares[0].clone());
+        let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
+                                               p2_their_encrypted_secret_shares[1].clone());
 
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
         let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
@@ -858,75 +859,76 @@ mod test {
         let (p4, p4coeffs, p4_dh_sk) = Participant::new(&params, false, 4, None, "Φ");
         let (p5, p5coeffs, p5_dh_sk) = Participant::new(&params, false, 5, None, "Φ");
 
-        let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs.unwrap(),
-                                                                 &mut p1_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs.unwrap(),
-                                                                 &mut p2_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-        let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p4.clone(), p5.clone());
-        let p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
-                                                                 &p3_dh_sk,
-                                                                 &p3.index,
-                                                                 &p3coeffs.unwrap(),
-                                                                 &mut p3_other_participants,
-                                                                 "Φ").unwrap();
+        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+                                                                  &p3_dh_sk,
+                                                                  &p3.index,
+                                                                  &p3coeffs.unwrap(),
+                                                                  &mut participants,
+                                                                  "Φ").unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-        let mut p4_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p5.clone());
-        let p4_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
                                                                  &p4coeffs.unwrap(),
-                                                                 &mut p4_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-        let mut p5_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone());
-        let p5_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+        let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
                                                                  &p5coeffs.unwrap(),
-                                                                 &mut p5_other_participants,
+                                                                 &mut participants,
                                                                  "Φ").unwrap();
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
-        let p1_my_encrypted_secret_shares = vec!(p2_their_encrypted_secret_shares[0].clone(), // XXX FIXME indexing
+        let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+                                       p2_their_encrypted_secret_shares[0].clone(),
                                        p3_their_encrypted_secret_shares[0].clone(),
                                        p4_their_encrypted_secret_shares[0].clone(),
                                        p5_their_encrypted_secret_shares[0].clone());
 
-        let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+        let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
+                                       p2_their_encrypted_secret_shares[1].clone(),
                                        p3_their_encrypted_secret_shares[1].clone(),
                                        p4_their_encrypted_secret_shares[1].clone(),
                                        p5_their_encrypted_secret_shares[1].clone());
 
-        let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
-                                       p2_their_encrypted_secret_shares[1].clone(),
+        let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
+                                       p2_their_encrypted_secret_shares[2].clone(),
+                                       p3_their_encrypted_secret_shares[2].clone(),
                                        p4_their_encrypted_secret_shares[2].clone(),
                                        p5_their_encrypted_secret_shares[2].clone());
 
-        let p4_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
-                                       p2_their_encrypted_secret_shares[2].clone(),
-                                       p3_their_encrypted_secret_shares[2].clone(),
-                                       p5_their_encrypted_secret_shares[3].clone());
-
-        let p5_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[3].clone(),
+        let p4_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[3].clone(),
                                        p2_their_encrypted_secret_shares[3].clone(),
                                        p3_their_encrypted_secret_shares[3].clone(),
-                                       p4_their_encrypted_secret_shares[3].clone());
+                                       p4_their_encrypted_secret_shares[3].clone(),
+                                       p5_their_encrypted_secret_shares[3].clone());
+
+        let p5_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[4].clone(),
+                                       p2_their_encrypted_secret_shares[4].clone(),
+                                       p3_their_encrypted_secret_shares[4].clone(),
+                                       p4_their_encrypted_secret_shares[4].clone(),
+                                       p5_their_encrypted_secret_shares[4].clone());
 
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
         let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
@@ -982,39 +984,40 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
 
-            let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs.unwrap(),
-                                                                     &mut p1_other_participants,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs.unwrap(),
-                                                                     &mut p2_other_participants,
+                                                                     &mut participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_dealer_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs.unwrap(),
-                                                                      &mut p3_other_participants,
+                                                                      &mut participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
-            let p1_my_encrypted_secret_shares = vec!(p2_their_encrypted_secret_shares[0].clone(), // XXX FIXME indexing
+            let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+                                           p2_their_encrypted_secret_shares[0].clone(),
                                            p3_their_encrypted_secret_shares[0].clone());
-            let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+            let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
+                                           p2_their_encrypted_secret_shares[1].clone(),
                                            p3_their_encrypted_secret_shares[1].clone());
-            let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
-                                           p2_their_encrypted_secret_shares[1].clone());
+            let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
+                                           p2_their_encrypted_secret_shares[2].clone(),
+                                           p3_their_encrypted_secret_shares[2].clone());
 
             let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -710,7 +710,7 @@ mod test {
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
         let mut participants: Vec<Participant> = vec![p1.clone()];
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -759,7 +759,7 @@ mod test {
         let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
 
         let mut participants: Vec<Participant> = vec![p1.clone()];
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -800,7 +800,7 @@ mod test {
         let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 
         let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -808,7 +808,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs,
@@ -860,7 +860,7 @@ mod test {
         let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
 
         let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
@@ -868,7 +868,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs,
@@ -876,7 +876,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                   &p3_dh_sk,
                                                                   &p3.index,
                                                                   &p3coeffs,
@@ -884,7 +884,7 @@ mod test {
                                                                   "Φ").unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-        let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
                                                                  &p4coeffs,
@@ -892,7 +892,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-        let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+        let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
                                                                  &p5coeffs,
@@ -985,7 +985,7 @@ mod test {
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
 
             let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -993,7 +993,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -1001,7 +1001,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
@@ -1084,7 +1084,7 @@ mod test {
             dealer3.proof_of_secret_key.as_ref().unwrap().verify(&dealer3.index, &dealer3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
-            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer1_dh_sk,
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
@@ -1092,7 +1092,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares()?;
 
-            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer2_dh_sk,
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
@@ -1100,7 +1100,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares()?;
 
-            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer3_dh_sk,
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
@@ -1143,19 +1143,19 @@ mod test {
                 Participant::reshare(&params, dealer3_secret_key.clone(), &mut signers, "Φ").map_err(|_| ())?;
 
             let mut dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
-            let signer1_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params,
+            let signer1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer2_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params,
+            let signer2_state = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer3_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params,
+            let signer3_state = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
                                                                      &mut dealers,
@@ -1294,7 +1294,7 @@ mod test {
             dealer3.proof_of_secret_key.as_ref().unwrap().verify(&dealer3.index, &dealer3.public_key().unwrap(), "Φ").or(Err(()))?;
 
             let mut dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
-            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params_dealers,
+            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer1_dh_sk,
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
@@ -1302,7 +1302,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares()?;
 
-            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params_dealers,
+            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer2_dh_sk,
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
@@ -1310,7 +1310,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares()?;
 
-            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params_dealers,
+            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer3_dh_sk,
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
@@ -1356,31 +1356,31 @@ mod test {
                 Participant::reshare(&params_signers, dealer3_secret_key.clone(), &mut signers, "Φ").map_err(|_| ())?;
 
             let mut dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
-            let signer1_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer1_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer2_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer2_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer3_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer3_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer4_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer4_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer4_dh_sk,
                                                                      &signer4.index,
                                                                      &mut dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer5_state = DistributedKeyGeneration::<RoundOne>::new_signer_state(&params_dealers,
+            let signer5_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer5_dh_sk,
                                                                      &signer5.index,
                                                                      &mut dealers,
@@ -1543,7 +1543,7 @@ mod test {
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
 
             let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
@@ -1551,7 +1551,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
@@ -1559,7 +1559,7 @@ mod test {
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial_state(&params,
+            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -709,12 +709,12 @@ mod test {
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
-        let mut participants: Vec<Participant> = vec![p1.clone()];
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let participants: Vec<Participant> = vec![p1.clone()];
+        let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
@@ -758,12 +758,12 @@ mod test {
 
         let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
 
-        let mut participants: Vec<Participant> = vec![p1.clone()];
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let participants: Vec<Participant> = vec![p1.clone()];
+        let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
@@ -799,20 +799,20 @@ mod test {
         let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
         let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
 
-        let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
+        let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
@@ -859,44 +859,44 @@ mod test {
         let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ");
         let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
 
-        let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
-        let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
+        let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p1_dh_sk,
                                                                  &p1.index,
                                                                  &p1coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-        let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p2_dh_sk,
                                                                  &p2.index,
                                                                  &p2coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-        let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                   &p3_dh_sk,
                                                                   &p3.index,
                                                                   &p3coeffs,
-                                                                  &mut participants,
+                                                                  &participants,
                                                                   "Φ").unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-        let p4_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p4_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p4_dh_sk,
                                                                  &p4.index,
                                                                  &p4coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-        let p5_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+        let (p5_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                  &p5_dh_sk,
                                                                  &p5.index,
                                                                  &p5coeffs,
-                                                                 &mut participants,
+                                                                 &participants,
                                                                  "Φ").unwrap();
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
@@ -984,28 +984,28 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
 
-            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
-                                                                      &mut participants,
+                                                                      &participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 
@@ -1083,28 +1083,28 @@ mod test {
             dealer2.proof_of_secret_key.as_ref().unwrap().verify(&dealer2.index, &dealer2.public_key().unwrap(), "Φ").or(Err(()))?;
             dealer3.proof_of_secret_key.as_ref().unwrap().verify(&dealer3.index, &dealer3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
-            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
+            let (dealer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer1_dh_sk,
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares()?;
 
-            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (dealer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer2_dh_sk,
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares()?;
 
-            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (dealer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &dealer3_dh_sk,
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer3_their_encrypted_secret_shares = dealer3_state.their_encrypted_secret_shares()?;
 
@@ -1133,32 +1133,32 @@ mod test {
             let (signer2, signer2_dh_sk) = Participant::new_signer(&params, 2, "Φ");
             let (signer3, signer3_dh_sk) = Participant::new_signer(&params, 3, "Φ");
 
-            let mut signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone());
+            let signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone());
 
-            let (dealer1_for_signers, dealer1_encrypted_shares_for_signers) =
-                Participant::reshare(&params, dealer1_secret_key.clone(), &mut signers, "Φ").map_err(|_| ())?;
-            let (dealer2_for_signers, dealer2_encrypted_shares_for_signers) =
-                Participant::reshare(&params, dealer2_secret_key.clone(), &mut signers, "Φ").map_err(|_| ())?;
-            let (dealer3_for_signers, dealer3_encrypted_shares_for_signers) =
-                Participant::reshare(&params, dealer3_secret_key.clone(), &mut signers, "Φ").map_err(|_| ())?;
+            let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params, dealer1_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+            let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params, dealer2_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+            let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params, dealer3_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
 
-            let mut dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
-            let signer1_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
+            let (signer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer2_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let (signer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer3_state = DistributedKeyGeneration::<RoundOne>::new(&params,
+            let (signer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
             let signer1_my_encrypted_secret_shares = vec!(dealer1_encrypted_shares_for_signers[0].clone(),
@@ -1293,28 +1293,28 @@ mod test {
             dealer2.proof_of_secret_key.as_ref().unwrap().verify(&dealer2.index, &dealer2.public_key().unwrap(), "Φ").or(Err(()))?;
             dealer3.proof_of_secret_key.as_ref().unwrap().verify(&dealer3.index, &dealer3.public_key().unwrap(), "Φ").or(Err(()))?;
 
-            let mut dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
-            let dealer1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
+            let dealers: Vec<Participant> = vec!(dealer1.clone(), dealer2.clone(), dealer3.clone());
+            let (dealer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer1_dh_sk,
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares()?;
 
-            let dealer2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
+            let (dealer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer2_dh_sk,
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares()?;
 
-            let dealer3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
+            let (dealer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
                                                                      &dealer3_dh_sk,
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
             let dealer3_their_encrypted_secret_shares = dealer3_state.their_encrypted_secret_shares()?;
 
@@ -1346,44 +1346,44 @@ mod test {
             let (signer4, signer4_dh_sk) = Participant::new_signer(&params_signers, 4, "Φ");
             let (signer5, signer5_dh_sk) = Participant::new_signer(&params_signers, 5, "Φ");
 
-            let mut signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone(), signer4.clone(), signer5.clone());
+            let signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone(), signer4.clone(), signer5.clone());
 
-            let (dealer1_for_signers, dealer1_encrypted_shares_for_signers) =
-                Participant::reshare(&params_signers, dealer1_secret_key.clone(), &mut signers, "Φ").map_err(|_| ())?;
-            let (dealer2_for_signers, dealer2_encrypted_shares_for_signers) =
-                Participant::reshare(&params_signers, dealer2_secret_key.clone(), &mut signers, "Φ").map_err(|_| ())?;
-            let (dealer3_for_signers, dealer3_encrypted_shares_for_signers) =
-                Participant::reshare(&params_signers, dealer3_secret_key.clone(), &mut signers, "Φ").map_err(|_| ())?;
+            let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params_signers, dealer1_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+            let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params_signers, dealer2_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+            let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
+                Participant::reshare(&params_signers, dealer3_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
 
-            let mut dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
-            let signer1_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
+            let (signer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer2_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let (signer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer3_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let (signer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer4_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let (signer4_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer4_dh_sk,
                                                                      &signer4.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
-            let signer5_state = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
+            let (signer5_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer5_dh_sk,
                                                                      &signer5.index,
-                                                                     &mut dealers,
+                                                                     &dealers,
                                                                      "Φ").or(Err(()))?;
 
             let signer1_my_encrypted_secret_shares = vec!(dealer1_encrypted_shares_for_signers[0].clone(),
@@ -1542,28 +1542,28 @@ mod test {
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ")?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ")?;
 
-            let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-            let p1_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+            let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p1_dh_sk,
                                                                      &p1.index,
                                                                      &p1coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares()?;
 
-            let p2_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                      &p2_dh_sk,
                                                                      &p2.index,
                                                                      &p2coeffs,
-                                                                     &mut participants,
+                                                                     &participants,
                                                                      "Φ").or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares()?;
 
-            let  p3_state = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
+            let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
                                                                       &p3_dh_sk,
                                                                       &p3.index,
                                                                       &p3coeffs,
-                                                                      &mut participants,
+                                                                      &participants,
                                                                       "Φ").or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares()?;
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -718,7 +718,7 @@ mod test {
                                                                  "Φ").unwrap();
         let p1_my_encrypted_secret_shares = Vec::new();
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
-        let result = p1_state.finish(p1.commitments.unwrap().points);
+        let result = p1_state.finish();
 
         assert!(result.is_ok());
 
@@ -768,7 +768,7 @@ mod test {
         let p1_my_encrypted_secret_shares = Vec::with_capacity(0);
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
+        let (group_key, p1_sk) = p1_state.finish().unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -823,8 +823,8 @@ mod test {
         let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
         let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
-        let (_, _p2_sk) = p2_state.finish(p2.commitments.unwrap().points).unwrap();
+        let (group_key, p1_sk) = p1_state.finish().unwrap();
+        let (_, _p2_sk) = p2_state.finish().unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -934,11 +934,11 @@ mod test {
         let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
         let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
 
-        let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
-        let (_, _) = p2_state.finish(p2.commitments.unwrap().points).unwrap();
-        let (_, p3_sk) = p3_state.finish(p3.commitments.unwrap().points).unwrap();
-        let (_, p4_sk) = p4_state.finish(p4.commitments.unwrap().points).unwrap();
-        let (_, _) = p5_state.finish(p5.commitments.unwrap().points).unwrap();
+        let (group_key, p1_sk) = p1_state.finish().unwrap();
+        let (_, _) = p2_state.finish().unwrap();
+        let (_, p3_sk) = p3_state.finish().unwrap();
+        let (_, p4_sk) = p4_state.finish().unwrap();
+        let (_, _) = p5_state.finish().unwrap();
 
         let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
         let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -1020,9 +1020,9 @@ mod test {
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
             let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
 
-            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.commitments.unwrap().points).or(Err(()))?;
-            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.commitments.unwrap().points).or(Err(()))?;
-            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.commitments.unwrap().points).or(Err(()))?;
+            let (p1_group_key, p1_secret_key) = p1_state.finish().or(Err(()))?;
+            let (p2_group_key, p2_secret_key) = p2_state.finish().or(Err(()))?;
+            let (p3_group_key, p3_secret_key) = p3_state.finish().or(Err(()))?;
 
             assert!(p1_group_key.0.compress() == p2_group_key.0.compress());
             assert!(p2_group_key.0.compress() == p3_group_key.0.compress());
@@ -1153,9 +1153,9 @@ mod test {
             let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
             let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
 
-            let (p1_group_key, p1_secret_key) = p1_state.finish(p1.commitments.unwrap().points).or(Err(()))?;
-            let (p2_group_key, p2_secret_key) = p2_state.finish(p2.commitments.unwrap().points).or(Err(()))?;
-            let (p3_group_key, p3_secret_key) = p3_state.finish(p3.commitments.unwrap().points).or(Err(()))?;
+            let (p1_group_key, p1_secret_key) = p1_state.finish().or(Err(()))?;
+            let (p2_group_key, p2_secret_key) = p2_state.finish().or(Err(()))?;
+            let (p3_group_key, p3_secret_key) = p3_state.finish().or(Err(()))?;
 
             assert!(p1_group_key.0.compress() == p2_group_key.0.compress());
             assert!(p2_group_key.0.compress() == p3_group_key.0.compress());

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -35,7 +35,7 @@ fn signing_and_verification_3_out_of_5() {
     let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
 
     let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
-    let p1_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+    let p1_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p1_dh_sk,
                                                              &p1.index,
                                                              &p1coeffs,
@@ -43,7 +43,7 @@ fn signing_and_verification_3_out_of_5() {
                                                              "Φ").unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-    let p2_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+    let p2_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p2_dh_sk,
                                                              &p2.index,
                                                              &p2coeffs,
@@ -51,7 +51,7 @@ fn signing_and_verification_3_out_of_5() {
                                                              "Φ").unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-    let  p3_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+    let  p3_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p3_dh_sk,
                                                              &p3.index,
                                                              &p3coeffs,
@@ -59,7 +59,7 @@ fn signing_and_verification_3_out_of_5() {
                                                              "Φ").unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-    let p4_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+    let p4_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p4_dh_sk,
                                                              &p4.index,
                                                              &p4coeffs,
@@ -67,7 +67,7 @@ fn signing_and_verification_3_out_of_5() {
                                                              "Φ").unwrap();
     let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-    let p5_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+    let p5_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p5_dh_sk,
                                                              &p5.index,
                                                              &p5coeffs,
@@ -157,7 +157,7 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 
     let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-    let p1_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+    let p1_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                       &p1_dh_sk,
                                                       &p1.index,
                                                       &p1coeffs,
@@ -165,7 +165,7 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
                                                       "Φ").unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-    let p2_state = DistributedKeyGeneration::<>::new_initial_state(&params,
+    let p2_state = DistributedKeyGeneration::<>::new_initial(&params,
                                                      &p2_dh_sk,
                                                      &p2.index,
                                                      &p2coeffs,
@@ -173,7 +173,7 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
                                                      "Φ").unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-    let p3_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+    let p3_state = DistributedKeyGeneration::<_>::new_initial(&params,
                                                       &p3_dh_sk,
                                                       &p3.index,
                                                       &p3coeffs,

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -110,11 +110,11 @@ fn signing_and_verification_3_out_of_5() {
     let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
     let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
 
-    let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
-    let (_, _) = p2_state.finish(p2.commitments.unwrap().points).unwrap();
-    let (_, p3_sk) = p3_state.finish(p3.commitments.unwrap().points).unwrap();
-    let (_, p4_sk) = p4_state.finish(p4.commitments.unwrap().points).unwrap();
-    let (_, _) = p5_state.finish(p5.commitments.unwrap().points).unwrap();
+    let (group_key, p1_sk) = p1_state.finish().unwrap();
+    let (_, _) = p2_state.finish().unwrap();
+    let (_, p3_sk) = p3_state.finish().unwrap();
+    let (_, p4_sk) = p4_state.finish().unwrap();
+    let (_, _) = p5_state.finish().unwrap();
 
     let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
     let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -195,9 +195,9 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
     let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).unwrap();
 
-    let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
-    let (_, p2_sk) = p2_state.finish(p2.commitments.unwrap().points).unwrap();
-    let (_, p3_sk) = p3_state.finish(p3.commitments.unwrap().points).unwrap();
+    let (group_key, p1_sk) = p1_state.finish().unwrap();
+    let (_, p2_sk) = p2_state.finish().unwrap();
+    let (_, p3_sk) = p3_state.finish().unwrap();
 
     let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
     let message = b"This is a test of the tsunami alert system. This is only a test.";

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -34,44 +34,44 @@ fn signing_and_verification_3_out_of_5() {
     let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ");
     let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
 
-    let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
-    let p1_state = DistributedKeyGeneration::<_>::new_initial(&params,
+    let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
+    let (p1_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p1_dh_sk,
                                                              &p1.index,
                                                              &p1coeffs,
-                                                             &mut participants,
+                                                             &participants,
                                                              "Φ").unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-    let p2_state = DistributedKeyGeneration::<_>::new_initial(&params,
+    let (p2_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p2_dh_sk,
                                                              &p2.index,
                                                              &p2coeffs,
-                                                             &mut participants,
+                                                             &participants,
                                                              "Φ").unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-    let  p3_state = DistributedKeyGeneration::<_>::new_initial(&params,
+    let (p3_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p3_dh_sk,
                                                              &p3.index,
                                                              &p3coeffs,
-                                                             &mut participants,
+                                                             &participants,
                                                              "Φ").unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-    let p4_state = DistributedKeyGeneration::<_>::new_initial(&params,
+    let (p4_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p4_dh_sk,
                                                              &p4.index,
                                                              &p4coeffs,
-                                                             &mut participants,
+                                                             &participants,
                                                              "Φ").unwrap();
     let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-    let p5_state = DistributedKeyGeneration::<_>::new_initial(&params,
+    let (p5_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                              &p5_dh_sk,
                                                              &p5.index,
                                                              &p5coeffs,
-                                                             &mut participants,
+                                                             &participants,
                                                              "Φ").unwrap();
     let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
@@ -156,28 +156,28 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
     let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 
-    let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
-    let p1_state = DistributedKeyGeneration::<_>::new_initial(&params,
+    let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+    let (p1_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                       &p1_dh_sk,
                                                       &p1.index,
                                                       &p1coeffs,
-                                                      &mut participants,
+                                                      &participants,
                                                       "Φ").unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-    let p2_state = DistributedKeyGeneration::<>::new_initial(&params,
+    let (p2_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                      &p2_dh_sk,
                                                      &p2.index,
                                                      &p2coeffs,
-                                                     &mut participants,
+                                                     &participants,
                                                      "Φ").unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-    let p3_state = DistributedKeyGeneration::<_>::new_initial(&params,
+    let (p3_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
                                                       &p3_dh_sk,
                                                       &p3.index,
                                                       &p3coeffs,
-                                                      &mut participants,
+                                                      &participants,
                                                       "Φ").unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -28,17 +28,17 @@ use ice_frost::SignatureAggregator;
 fn signing_and_verification_3_out_of_5() {
     let params = Parameters { n: 5, t: 3 };
 
-    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
-    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
-    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
-    let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, None, "Φ");
-    let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, None, "Φ");
+    let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
+    let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
+    let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
+    let (p4, p4coeffs, p4_dh_sk) = Participant::new(&params, false, 4, None, "Φ");
+    let (p5, p5coeffs, p5_dh_sk) = Participant::new(&params, false, 5, None, "Φ");
 
     let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone(), p4.clone(), p5.clone());
     let p1_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p1_dh_sk,
                                                       &p1.index,
-                                                      &p1coeffs,
+                                                      &p1coeffs.unwrap(),
                                                       &mut p1_other_participants,
                                                       "Φ").unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
@@ -47,7 +47,7 @@ fn signing_and_verification_3_out_of_5() {
     let p2_state = DistributedKeyGeneration::<>::new_dealer_state(&params,
                                                      &p2_dh_sk,
                                                      &p2.index,
-                                                     &p2coeffs,
+                                                     &p2coeffs.unwrap(),
                                                      &mut p2_other_participants,
                                                      "Φ").unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
@@ -56,7 +56,7 @@ fn signing_and_verification_3_out_of_5() {
     let p3_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p3_dh_sk,
                                                       &p3.index,
-                                                      &p3coeffs,
+                                                      &p3coeffs.unwrap(),
                                                       &mut p3_other_participants,
                                                       "Φ").unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
@@ -65,7 +65,7 @@ fn signing_and_verification_3_out_of_5() {
     let p4_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p4_dh_sk,
                                                       &p4.index,
-                                                      &p4coeffs,
+                                                      &p4coeffs.unwrap(),
                                                       &mut p4_other_participants,
                                                       "Φ").unwrap();
     let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
@@ -74,7 +74,7 @@ fn signing_and_verification_3_out_of_5() {
     let p5_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p5_dh_sk,
                                                       &p5.index,
-                                                      &p5coeffs,
+                                                      &p5coeffs.unwrap(),
                                                       &mut p5_other_participants,
                                                       "Φ").unwrap();
     let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
@@ -151,15 +151,15 @@ fn signing_and_verification_3_out_of_5() {
 fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let params = Parameters { n: 3, t: 2 };
 
-    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
-    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
-    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
+    let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
+    let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
+    let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
 
     let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
     let p1_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p1_dh_sk,
                                                       &p1.index,
-                                                      &p1coeffs,
+                                                      &p1coeffs.unwrap(),
                                                       &mut p1_other_participants,
                                                       "Φ").unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
@@ -168,7 +168,7 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let p2_state = DistributedKeyGeneration::<>::new_dealer_state(&params,
                                                      &p2_dh_sk,
                                                      &p2.index,
-                                                     &p2coeffs,
+                                                     &p2coeffs.unwrap(),
                                                      &mut p2_other_participants,
                                                      "Φ").unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
@@ -177,7 +177,7 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let p3_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p3_dh_sk,
                                                       &p3.index,
-                                                      &p3coeffs,
+                                                      &p3coeffs.unwrap(),
                                                       &mut p3_other_participants,
                                                       "Φ").unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -28,14 +28,14 @@ use ice_frost::SignatureAggregator;
 fn signing_and_verification_3_out_of_5() {
     let params = Parameters { n: 5, t: 3 };
 
-    let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, 1, "Φ");
-    let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, 2, "Φ");
-    let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, 3, "Φ");
-    let (p4, p4coeffs, p4_dh_sk) = Participant::new(&params, 4, "Φ");
-    let (p5, p5coeffs, p5_dh_sk) = Participant::new(&params, 5, "Φ");
+    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
+    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
+    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
+    let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, None, "Φ");
+    let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, None, "Φ");
 
     let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone(), p4.clone(), p5.clone());
-    let p1_state = DistributedKeyGeneration::<_>::new(&params,
+    let p1_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p1_dh_sk,
                                                       &p1.index,
                                                       &p1coeffs,
@@ -44,7 +44,7 @@ fn signing_and_verification_3_out_of_5() {
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
     let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone(), p4.clone(), p5.clone());
-    let p2_state = DistributedKeyGeneration::<>::new(&params,
+    let p2_state = DistributedKeyGeneration::<>::new_dealer_state(&params,
                                                      &p2_dh_sk,
                                                      &p2.index,
                                                      &p2coeffs,
@@ -53,7 +53,7 @@ fn signing_and_verification_3_out_of_5() {
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
     let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p4.clone(), p5.clone());
-    let p3_state = DistributedKeyGeneration::<_>::new(&params,
+    let p3_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p3_dh_sk,
                                                       &p3.index,
                                                       &p3coeffs,
@@ -62,7 +62,7 @@ fn signing_and_verification_3_out_of_5() {
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
     let mut p4_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p5.clone());
-    let p4_state = DistributedKeyGeneration::<_>::new(&params,
+    let p4_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p4_dh_sk,
                                                       &p4.index,
                                                       &p4coeffs,
@@ -71,7 +71,7 @@ fn signing_and_verification_3_out_of_5() {
     let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
     let mut p5_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone());
-    let p5_state = DistributedKeyGeneration::<_>::new(&params,
+    let p5_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p5_dh_sk,
                                                       &p5.index,
                                                       &p5coeffs,
@@ -110,11 +110,11 @@ fn signing_and_verification_3_out_of_5() {
     let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
     let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
 
-    let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
-    let (_, _) = p2_state.finish(p2.commitments.points).unwrap();
-    let (_, p3_sk) = p3_state.finish(p3.commitments.points).unwrap();
-    let (_, p4_sk) = p4_state.finish(p4.commitments.points).unwrap();
-    let (_, _) = p5_state.finish(p5.commitments.points).unwrap();
+    let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
+    let (_, _) = p2_state.finish(p2.commitments.unwrap().points).unwrap();
+    let (_, p3_sk) = p3_state.finish(p3.commitments.unwrap().points).unwrap();
+    let (_, p4_sk) = p4_state.finish(p4.commitments.unwrap().points).unwrap();
+    let (_, _) = p5_state.finish(p5.commitments.unwrap().points).unwrap();
 
     let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
     let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -151,12 +151,12 @@ fn signing_and_verification_3_out_of_5() {
 fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let params = Parameters { n: 3, t: 2 };
 
-    let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, 1, "Φ");
-    let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, 2, "Φ");
-    let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, 3, "Φ");
+    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, None, "Φ");
+    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, None, "Φ");
+    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, None, "Φ");
 
     let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-    let p1_state = DistributedKeyGeneration::<_>::new(&params,
+    let p1_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p1_dh_sk,
                                                       &p1.index,
                                                       &p1coeffs,
@@ -165,7 +165,7 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
     let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-    let p2_state = DistributedKeyGeneration::<>::new(&params,
+    let p2_state = DistributedKeyGeneration::<>::new_dealer_state(&params,
                                                      &p2_dh_sk,
                                                      &p2.index,
                                                      &p2coeffs,
@@ -174,7 +174,7 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
     let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-    let p3_state = DistributedKeyGeneration::<_>::new(&params,
+    let p3_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
                                                       &p3_dh_sk,
                                                       &p3.index,
                                                       &p3coeffs,
@@ -195,9 +195,9 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
     let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).unwrap();
 
-    let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
-    let (_, p2_sk) = p2_state.finish(p2.commitments.points).unwrap();
-    let (_, p3_sk) = p3_state.finish(p3.commitments.points).unwrap();
+    let (group_key, p1_sk) = p1_state.finish(p1.commitments.unwrap().points).unwrap();
+    let (_, p2_sk) = p2_state.finish(p2.commitments.unwrap().points).unwrap();
+    let (_, p3_sk) = p3_state.finish(p3.commitments.unwrap().points).unwrap();
 
     let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
     let message = b"This is a test of the tsunami alert system. This is only a test.";

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -110,11 +110,11 @@ fn signing_and_verification_3_out_of_5() {
     let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
     let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
 
-    let (group_key, p1_sk) = p1_state.finish(p1.public_key().unwrap()).unwrap();
-    let (_, _) = p2_state.finish(p2.public_key().unwrap()).unwrap();
-    let (_, p3_sk) = p3_state.finish(p3.public_key().unwrap()).unwrap();
-    let (_, p4_sk) = p4_state.finish(p4.public_key().unwrap()).unwrap();
-    let (_, _) = p5_state.finish(p5.public_key().unwrap()).unwrap();
+    let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
+    let (_, _) = p2_state.finish(p2.commitments.points).unwrap();
+    let (_, p3_sk) = p3_state.finish(p3.commitments.points).unwrap();
+    let (_, p4_sk) = p4_state.finish(p4.commitments.points).unwrap();
+    let (_, _) = p5_state.finish(p5.commitments.points).unwrap();
 
     let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
     let message = b"This is a test of the tsunami alert system. This is only a test.";
@@ -195,9 +195,9 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
     let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).unwrap();
 
-    let (group_key, p1_sk) = p1_state.finish(p1.public_key().unwrap()).unwrap();
-    let (_, p2_sk) = p2_state.finish(p2.public_key().unwrap()).unwrap();
-    let (_, p3_sk) = p3_state.finish(p3.public_key().unwrap()).unwrap();
+    let (group_key, p1_sk) = p1_state.finish(p1.commitments.points).unwrap();
+    let (_, p2_sk) = p2_state.finish(p2.commitments.points).unwrap();
+    let (_, p3_sk) = p3_state.finish(p3.commitments.points).unwrap();
 
     let context = b"CONTEXT STRING STOLEN FROM DALEK TEST SUITE";
     let message = b"This is a test of the tsunami alert system. This is only a test.";

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -28,81 +28,82 @@ use ice_frost::SignatureAggregator;
 fn signing_and_verification_3_out_of_5() {
     let params = Parameters { n: 5, t: 3 };
 
-    let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
-    let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
-    let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
-    let (p4, p4coeffs, p4_dh_sk) = Participant::new(&params, false, 4, None, "Φ");
-    let (p5, p5coeffs, p5_dh_sk) = Participant::new(&params, false, 5, None, "Φ");
+    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+    let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ");
+    let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
 
-    let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone(), p4.clone(), p5.clone());
-    let p1_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
-                                                      &p1_dh_sk,
-                                                      &p1.index,
-                                                      &p1coeffs.unwrap(),
-                                                      &mut p1_other_participants,
-                                                      "Φ").unwrap();
+    let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
+    let p1_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+                                                             &p1_dh_sk,
+                                                             &p1.index,
+                                                             &p1coeffs,
+                                                             &mut participants,
+                                                             "Φ").unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-    let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone(), p4.clone(), p5.clone());
-    let p2_state = DistributedKeyGeneration::<>::new_dealer_state(&params,
-                                                     &p2_dh_sk,
-                                                     &p2.index,
-                                                     &p2coeffs.unwrap(),
-                                                     &mut p2_other_participants,
-                                                     "Φ").unwrap();
+    let p2_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+                                                             &p2_dh_sk,
+                                                             &p2.index,
+                                                             &p2coeffs,
+                                                             &mut participants,
+                                                             "Φ").unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-    let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p4.clone(), p5.clone());
-    let p3_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
-                                                      &p3_dh_sk,
-                                                      &p3.index,
-                                                      &p3coeffs.unwrap(),
-                                                      &mut p3_other_participants,
-                                                      "Φ").unwrap();
+    let  p3_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+                                                             &p3_dh_sk,
+                                                             &p3.index,
+                                                             &p3coeffs,
+                                                             &mut participants,
+                                                             "Φ").unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-    let mut p4_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p5.clone());
-    let p4_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
-                                                      &p4_dh_sk,
-                                                      &p4.index,
-                                                      &p4coeffs.unwrap(),
-                                                      &mut p4_other_participants,
-                                                      "Φ").unwrap();
+    let p4_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+                                                             &p4_dh_sk,
+                                                             &p4.index,
+                                                             &p4coeffs,
+                                                             &mut participants,
+                                                             "Φ").unwrap();
     let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
-    let mut p5_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone());
-    let p5_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
-                                                      &p5_dh_sk,
-                                                      &p5.index,
-                                                      &p5coeffs.unwrap(),
-                                                      &mut p5_other_participants,
-                                                      "Φ").unwrap();
+    let p5_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
+                                                             &p5_dh_sk,
+                                                             &p5.index,
+                                                             &p5coeffs,
+                                                             &mut participants,
+                                                             "Φ").unwrap();
     let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
-    let p1_my_encrypted_secret_shares = vec!(p2_their_encrypted_secret_shares[0].clone(), // XXX FIXME indexing
+    let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+                                   p2_their_encrypted_secret_shares[0].clone(),
                                    p3_their_encrypted_secret_shares[0].clone(),
                                    p4_their_encrypted_secret_shares[0].clone(),
                                    p5_their_encrypted_secret_shares[0].clone());
 
-    let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+    let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
+                                   p2_their_encrypted_secret_shares[1].clone(),
                                    p3_their_encrypted_secret_shares[1].clone(),
                                    p4_their_encrypted_secret_shares[1].clone(),
                                    p5_their_encrypted_secret_shares[1].clone());
 
-    let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
-                                   p2_their_encrypted_secret_shares[1].clone(),
+    let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
+                                   p2_their_encrypted_secret_shares[2].clone(),
+                                   p3_their_encrypted_secret_shares[2].clone(),
                                    p4_their_encrypted_secret_shares[2].clone(),
                                    p5_their_encrypted_secret_shares[2].clone());
 
-    let p4_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
-                                   p2_their_encrypted_secret_shares[2].clone(),
-                                   p3_their_encrypted_secret_shares[2].clone(),
-                                   p5_their_encrypted_secret_shares[3].clone());
-
-    let p5_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[3].clone(),
+    let p4_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[3].clone(),
                                    p2_their_encrypted_secret_shares[3].clone(),
                                    p3_their_encrypted_secret_shares[3].clone(),
-                                   p4_their_encrypted_secret_shares[3].clone());
+                                   p4_their_encrypted_secret_shares[3].clone(),
+                                   p5_their_encrypted_secret_shares[3].clone());
+
+    let p5_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[4].clone(),
+                                   p2_their_encrypted_secret_shares[4].clone(),
+                                   p3_their_encrypted_secret_shares[4].clone(),
+                                   p4_their_encrypted_secret_shares[4].clone(),
+                                   p5_their_encrypted_secret_shares[4].clone());
 
     let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
     let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
@@ -151,45 +152,46 @@ fn signing_and_verification_3_out_of_5() {
 fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let params = Parameters { n: 3, t: 2 };
 
-    let (p1, p1coeffs, p1_dh_sk) = Participant::new(&params, false, 1, None, "Φ");
-    let (p2, p2coeffs, p2_dh_sk) = Participant::new(&params, false, 2, None, "Φ");
-    let (p3, p3coeffs, p3_dh_sk) = Participant::new(&params, false, 3, None, "Φ");
+    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
 
-    let mut p1_other_participants: Vec<Participant> = vec!(p2.clone(), p3.clone());
-    let p1_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
+    let mut participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
+    let p1_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
                                                       &p1_dh_sk,
                                                       &p1.index,
-                                                      &p1coeffs.unwrap(),
-                                                      &mut p1_other_participants,
+                                                      &p1coeffs,
+                                                      &mut participants,
                                                       "Φ").unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
-    let mut p2_other_participants: Vec<Participant> = vec!(p1.clone(), p3.clone());
-    let p2_state = DistributedKeyGeneration::<>::new_dealer_state(&params,
+    let p2_state = DistributedKeyGeneration::<>::new_initial_state(&params,
                                                      &p2_dh_sk,
                                                      &p2.index,
-                                                     &p2coeffs.unwrap(),
-                                                     &mut p2_other_participants,
+                                                     &p2coeffs,
+                                                     &mut participants,
                                                      "Φ").unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
-    let mut p3_other_participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
-    let p3_state = DistributedKeyGeneration::<_>::new_dealer_state(&params,
+    let p3_state = DistributedKeyGeneration::<_>::new_initial_state(&params,
                                                       &p3_dh_sk,
                                                       &p3.index,
-                                                      &p3coeffs.unwrap(),
-                                                      &mut p3_other_participants,
+                                                      &p3coeffs,
+                                                      &mut participants,
                                                       "Φ").unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
-    let p1_my_encrypted_secret_shares = vec!(p2_their_encrypted_secret_shares[0].clone(), // XXX FIXME indexing
+    let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+                                   p2_their_encrypted_secret_shares[0].clone(),
                                    p3_their_encrypted_secret_shares[0].clone());
 
-    let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
+    let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
+                                   p2_their_encrypted_secret_shares[1].clone(),
                                    p3_their_encrypted_secret_shares[1].clone());
 
-    let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
-                                   p2_their_encrypted_secret_shares[1].clone());
+    let p3_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[2].clone(),
+                                   p2_their_encrypted_secret_shares[2].clone(),
+                                   p3_their_encrypted_secret_shares[2].clone());
 
     let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
     let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();


### PR DESCRIPTION
This PR introduces the static version (i.e. the possibility of having a single group key for different sets of participants with resharing) of ICE-FROST.

It requires a distinction between the initial DKG protocol (similar to existing ICE-FROST DKG with no prior shares) and other DKGs where participants gather encrypted shares from participants of a previous set. There is also a distinction between participants, namely dealers (who can sign and distribute shares of their long-lived private signing key, or generate a new group key from scratch) and signers (who can sign and distribute shares of their long-lived private signing key, but cannot generate a new group key).

Documentation within the crate main and keygen modules has been added, detailing the process of key generation, shares redistribution, and key "regeneration" from another set of participants of different size. You can compile it with `cargo doc` and open locally the documentation file (located at frost/target/doc/frost_dalek/index.html) to navigate through the documentation related to Key Resharing.

The PR closes #1 as we now generate also encrypted shares for ourselves, hence making indexing easier
