### PR TITLE
Remove Hashbrown dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ rand = { version = "0.7", default-features = false, features = ["alloc", "getran
 sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
-hashbrown = { version = "0.11", default-features = false, features = ["ahash", "inline-more"] }
 aes = { version = "0.7", default-features = false, features = ["ctr"] }
 hkdf = { version = "0.11", default-features = false }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,13 +662,13 @@
 //! ```
 //!
 //! If the aggregator could not finalize the state, then the `.finalize()` method
-//! will return a `HashMap<u32, &'static str>` describing participant indices and the issues
+//! will return a `BTreeMap<u32, &'static str>` describing participant indices and the issues
 //! encountered for them.  These issues are **guaranteed to be the fault of the aggregator**,
 //! e.g. not collecting all the expected partial signatures, accepting two partial
 //! signatures from the same participant, etc.
 //!
 //! And the same for the actual aggregation, if there was an error then a
-//! `HashMap<u32, &'static str>` will be returned which maps participant indices to issues.
+//! `BTreeMap<u32, &'static str>` will be returned which maps participant indices to issues.
 //! Unlike before, however, these issues are guaranteed to be the fault of the
 //! corresponding participant, specifically, that their partial signature was invalid.
 //!


### PR DESCRIPTION
This PR removes the hashbrown dependency, by relying on `BTreeMap` instead, from `std::collections` or `alloc::collections` depending on which feature is activated.

Signature operations performances are barely affected at all. Only partial signature creation is about 6% slower because `BTreeMap` doesn't have a `with_capacity()` method, but it's taking about 10ns so completely negligible.

closes #15 