### PR TITLE
Error type + Relax Rng

### DIFF
--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -70,17 +70,19 @@
 //! use curve25519_dalek::ristretto::RistrettoPoint;
 //! use curve25519_dalek::traits::Identity;
 //! use curve25519_dalek::scalar::Scalar;
+//! use rand::rngs::OsRng;
 //!
 //! # fn do_test() -> Result<(), ()> {
 //! // Set up key shares for a threshold signature scheme which needs at least
 //! // 2-out-of-3 signers.
 //! let params = Parameters { t: 2, n: 3 };
+//! let mut rng = OsRng;
 //!
 //! // Alice, Bob, and Carol each generate their secret polynomial coefficients
 //! // and commitments to them, as well as a zero-knowledge proof of a secret key.
-//! let (alice, alice_coeffs, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coeffs, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coeffs, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coeffs, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coeffs, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coeffs, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //!
 //! // They send these values to each of the other participants (out of scope
 //! // for this library), or otherwise publish them somewhere.
@@ -118,6 +120,7 @@
 //!         &alice_coeffs,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //!
@@ -136,6 +139,7 @@
 //!         &bob_coeffs,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //!
@@ -154,6 +158,7 @@
 //!         &carol_coeffs,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //!
@@ -176,9 +181,9 @@
 //!
 //! // The participants then use these secret shares from the other participants to advance to
 //! // round two of the distributed key generation protocol.
-//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //!
 //! // Each participant can now derive their long-lived secret keys and the group's
 //! // public key.
@@ -211,17 +216,19 @@
 //! use curve25519_dalek::ristretto::RistrettoPoint;
 //! use curve25519_dalek::traits::Identity;
 //! use curve25519_dalek::scalar::Scalar;
+//! use rand::rngs::OsRng;
 //! 
 //! # fn do_test() -> Result<(), ()> {
 //! // Set up key shares for a threshold signature scheme which needs at least
 //! // 2-out-of-3 signers.
 //! let params = Parameters { t: 2, n: 3 };
+//! let mut rng = OsRng;
 //!
 //! // Alice, Bob, and Carol each generate their secret polynomial coefficients
 //! // and commitments to them, as well as a zero-knowledge proof of a secret key.
-//! let (alice, alice_coeffs, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coeffs, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coeffs, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coeffs, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coeffs, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coeffs, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! 
 //! // They send these values to each of the other participants (out of scope
 //! // for this library), or otherwise publish them somewhere.
@@ -259,6 +266,7 @@
 //!         &alice_coeffs,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //!
@@ -277,6 +285,7 @@
 //!         &bob_coeffs,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //!
@@ -295,6 +304,7 @@
 //!         &carol_coeffs,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //!
@@ -317,9 +327,9 @@
 //!
 //! // The participants then use these secret shares from the other participants to advance to
 //! // round two of the distributed key generation protocol.
-//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //!
 //! // Each participant can now derive their long-lived secret keys and the group's
 //! // public key.
@@ -336,10 +346,10 @@
 //! 
 //! // Alexis, Barbara, Claire and David each generate their Diffie-Hellman
 //! // private key, as well as a zero-knowledge proof to it.
-//! let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ");
-//! let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ");
-//! let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
-//! let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
+//! let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ", &mut rng);
+//! let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ", &mut rng);
+//! let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ", &mut rng);
+//! let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ", &mut rng);
 //!
 //! // They send these values to each of the other and previous participants
 //! // (out of scope for this library), or otherwise publish them somewhere.
@@ -381,13 +391,13 @@
 //! let signers: Vec<Participant> =
 //!     vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
 //! let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
+//!     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! 
 //! let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
+//!     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! 
 //! let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
+//!     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! 
 //! // NOTE: They use the *new* configuration parameters (3-out-of-4) when resharing.
 //! 
@@ -401,7 +411,8 @@
 //!         &alexis_dh_sk,
 //!         &alexis.index,
 //!         &dealers,
-//!         "Φ"
+//!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //! 
@@ -411,7 +422,8 @@
 //!         &barbara_dh_sk,
 //!         &barbara.index,
 //!         &dealers,
-//!         "Φ"
+//!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //! 
@@ -421,7 +433,8 @@
 //!         &claire_dh_sk,
 //!         &claire.index,
 //!         &dealers,
-//!         "Φ"
+//!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //! 
@@ -431,7 +444,8 @@
 //!         &david_dh_sk,
 //!         &david.index,
 //!         &dealers,
-//!         "Φ"
+//!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //! 
@@ -461,10 +475,10 @@
 //! // DKG ran by Alice, Bob and Carol. The final group key of the 3-out-of-4 threshold scheme
 //! // configuration will be identical to the one of the 2-out-of-3 original one.
 //! 
-//! let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares).or(Err(()))?;
-//! let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares).or(Err(()))?;
-//! let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares).or(Err(()))?;
-//! let david_state = david_state.to_round_two(david_my_encrypted_secret_shares).or(Err(()))?;
+//! let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let david_state = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! 
 //! let (alexis_group_key, alexis_secret_key) = alexis_state.finish().or(Err(()))?;
 //! let (barbara_group_key, barbara_secret_key) = barbara_state.finish().or(Err(()))?;
@@ -506,7 +520,7 @@ use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::Identity;
 
-use rand::rngs::OsRng;
+use rand::CryptoRng;
 use rand::RngCore;
 
 use sha2::Digest;
@@ -843,11 +857,12 @@ impl Participant {
     pub fn new_dealer(
         parameters: &Parameters,
         index: u32,
-        context_string: &str
+        context_string: &str,
+        mut rng: impl RngCore + CryptoRng,
     ) -> (Self, Coefficients, DHPrivateKey)
     {
         let (dealer, coeff_option, dh_private_key) =
-            Self::new_internal(parameters, false, index, None, context_string);
+            Self::new_internal(parameters, false, index, None, context_string, &mut rng);
         (dealer, coeff_option.unwrap(), dh_private_key)
     }
 
@@ -876,11 +891,12 @@ impl Participant {
     pub fn new_signer(
         parameters: &Parameters,
         index: u32,
-        context_string: &str
+        context_string: &str,
+        mut rng: impl RngCore + CryptoRng,
     ) -> (Self, DHPrivateKey)
     {
         let (signer, _coeff_option, dh_private_key) =
-            Self::new_internal(parameters, true, index, None, context_string);
+            Self::new_internal(parameters, true, index, None, context_string, &mut rng);
         (signer, dh_private_key)
     }
 
@@ -889,7 +905,8 @@ impl Participant {
         is_signer: bool,
         index: u32,
         secret_key: Option<Scalar>,
-        context_string: &str
+        context_string: &str,
+        mut rng: impl RngCore + CryptoRng,
     ) -> (Self, Option<Coefficients>, DHPrivateKey)
     {
         // Step 1: Every participant P_i samples t random values (a_{i0}, ..., a_{i(t-1)})
@@ -897,7 +914,6 @@ impl Participant {
         //         polynomial f_i(x) = \sum_{j=0}^{t-1} a_{ij} x^{j} of degree t-1 over
         //         ZZ_q.
         let t: usize = parameters.t as usize;
-        let mut rng: OsRng = OsRng;
 
         // RICE-FROST: Every participant samples a random pair of keys (dh_private_key, dh_public_key)
         // and generates a proof of knowledge of dh_private_key. This will be used for secret shares
@@ -908,7 +924,7 @@ impl Participant {
 
         // Compute a proof of knowledge of dh_secret_key
         let proof_of_dh_private_key: NizkOfSecretKey =
-            NizkOfSecretKey::prove(&index, &dh_private_key, &dh_public_key, &context_string, rng);
+            NizkOfSecretKey::prove(&index, &dh_private_key, &dh_public_key, &context_string, &mut rng);
 
         if is_signer {
             // Signers don't need coefficients, commitments or proofs of secret key.
@@ -995,11 +1011,12 @@ impl Participant {
         parameters: &Parameters,
         secret_key: SecretKey,
         signers: &[Participant],
-        context_string: &str
+        context_string: &str,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<(Self, Vec<EncryptedSecretShare>, DKGParticipantList), Error>
     {
         let (dealer, coeff_option, dh_private_key) =
-            Self::new_internal(parameters, false, secret_key.index, Some(secret_key.key), context_string);
+            Self::new_internal(parameters, false, secret_key.index, Some(secret_key.key), context_string, &mut rng);
 
         // Unwrapping cannot panic here
         let coefficients = coeff_option.unwrap();
@@ -1013,6 +1030,7 @@ impl Participant {
             context_string,
             true,
             false,
+            &mut rng,
         )?;
 
         // Unwrapping cannot panic here
@@ -1402,13 +1420,16 @@ pub trait Round2: private::Sealed {}
 impl Round1 for RoundOne {}
 impl Round2 for RoundTwo {}
 
-fn encrypt_share(share: &SecretShare, aes_key: &[u8; 32]) -> EncryptedSecretShare {
+fn encrypt_share(
+    share: &SecretShare,
+    aes_key: &[u8; 32],
+    mut rng: impl RngCore + CryptoRng
+) -> EncryptedSecretShare {
     let hkdf = Hkdf::<Sha512>::new(None, &aes_key[..]);
     let mut final_aes_key = [0u8; 32];
     hkdf.expand(&[], &mut final_aes_key)
         .expect("KDF expansion failed unexpectedly");
 
-    let mut rng: OsRng = OsRng;
     let mut nonce_array = [0u8; 16];
     rng.fill_bytes(&mut nonce_array);
 
@@ -1490,6 +1511,7 @@ impl DistributedKeyGeneration<RoundOne> {
         my_coefficients: &Coefficients,
         participants: &[Participant],
         context_string: &str,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<(Self, DKGParticipantList), Error>
     {
         Self::new_state_internal(
@@ -1501,6 +1523,7 @@ impl DistributedKeyGeneration<RoundOne> {
             context_string,
             true,
             true,
+            &mut rng,
         )
     }
 
@@ -1524,6 +1547,7 @@ impl DistributedKeyGeneration<RoundOne> {
         my_index: &u32,
         dealers: &[Participant],
         context_string: &str,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<(Self, DKGParticipantList), Error>
     {
         Self::new_state_internal(
@@ -1535,6 +1559,7 @@ impl DistributedKeyGeneration<RoundOne> {
             context_string,
             false,
             true,
+            &mut rng
         )
     }
 
@@ -1547,6 +1572,7 @@ impl DistributedKeyGeneration<RoundOne> {
         context_string: &str,
         from_dealer: bool,
         from_signer: bool,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<(Self, DKGParticipantList), Error>
     {
         let mut their_commitments: Vec<VerifiableSecretSharingCommitment> = Vec::with_capacity(parameters.t as usize);
@@ -1643,7 +1669,7 @@ impl DistributedKeyGeneration<RoundOne> {
 
             let dh_key = (p.dh_public_key.0 * dh_private_key.0).compress().to_bytes();
 
-            their_encrypted_secret_shares.push(encrypt_share(&share, &dh_key));
+            their_encrypted_secret_shares.push(encrypt_share(&share, &dh_key, &mut rng));
         }
 
         let state = ActualState {
@@ -1690,6 +1716,7 @@ impl DistributedKeyGeneration<RoundOne> {
     pub fn to_round_two(
         mut self,
         my_encrypted_secret_shares: Vec<EncryptedSecretShare>,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Result<DistributedKeyGeneration<RoundTwo>, Error>
     {
         // Zero out the other participants encrypted secret shares from memory.
@@ -1729,7 +1756,6 @@ impl DistributedKeyGeneration<RoundOne> {
 
                             if decrypted_share.is_err() || decrypted_share_ref.as_ref().unwrap().verify(commitment).is_err() {
 
-                                let mut rng: OsRng = OsRng;
                                 let r = Scalar::random(&mut rng);
 
                                 let a1 = &RISTRETTO_BASEPOINT_TABLE * &r;
@@ -2465,11 +2491,14 @@ impl GroupKey {
 mod test {
     use super::*;
     use rand::Rng;
+    use rand::rngs::OsRng;
 
     #[test]
     fn nizk_of_secret_key() {
         let params = Parameters { n: 3, t: 2 };
-        let (p, _, _) = Participant::new_dealer(&params, 0, "Φ");
+        let mut rng = OsRng;
+
+        let (p, _, _) = Participant::new_dealer(&params, 0, "Φ", &mut rng);
         let result = p.proof_of_secret_key.as_ref().unwrap().verify(&p.index, &p.public_key().unwrap(), "Φ");
 
         assert!(result.is_ok());
@@ -2522,8 +2551,9 @@ mod test {
     #[test]
     fn single_party_keygen() {
         let params = Parameters { n: 1, t: 1 };
+        let mut rng = OsRng;
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
@@ -2533,9 +2563,10 @@ mod test {
                                                                  &p1.index,
                                                                  &p1coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
-        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
+        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).unwrap();
         let result = p1_state.finish();
 
         assert!(result.is_ok());
@@ -2548,12 +2579,13 @@ mod test {
     #[test]
     fn keygen_3_out_of_5() {
         let params = Parameters { n: 5, t: 3 };
+        let mut rng = OsRng;
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-        let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
-        let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ");
-        let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+        let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
+        let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ", &mut rng);
+        let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ", &mut rng);
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
         p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").unwrap();
@@ -2567,7 +2599,8 @@ mod test {
                                                                  &p1.index,
                                                                  &p1coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
         let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -2575,7 +2608,8 @@ mod test {
                                                                  &p2.index,
                                                                  &p2coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
         let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -2583,7 +2617,8 @@ mod test {
                                                                   &p3.index,
                                                                   &p3coeffs,
                                                                   &participants,
-                                                                  "Φ").unwrap();
+                                                                  "Φ",
+                                                                  &mut rng).unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
         let (p4_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -2591,7 +2626,8 @@ mod test {
                                                                  &p4.index,
                                                                  &p4coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
         let (p5_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -2599,7 +2635,8 @@ mod test {
                                                                  &p5.index,
                                                                  &p5coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
         let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -2632,11 +2669,11 @@ mod test {
                                        p4_their_encrypted_secret_shares[4].clone(),
                                        p5_their_encrypted_secret_shares[4].clone());
 
-        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
-        let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
-        let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).unwrap();
-        let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
-        let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
+        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares, &mut rng).unwrap();
 
         let (p1_group_key, p1_secret_key) = p1_state.finish().unwrap();
         let (p2_group_key, p2_secret_key) = p2_state.finish().unwrap();
@@ -2668,10 +2705,11 @@ mod test {
     fn keygen_2_out_of_3() {
         fn do_test() -> Result<(), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng = OsRng;
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").or(Err(()))?;
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -2683,7 +2721,8 @@ mod test {
                                                                      &p1.index,
                                                                      &p1coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -2691,7 +2730,8 @@ mod test {
                                                                      &p2.index,
                                                                      &p2coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -2699,7 +2739,8 @@ mod test {
                                                                       &p3.index,
                                                                       &p3coeffs,
                                                                       &participants,
-                                                                      "Φ").or(Err(()))?;
+                                                                      "Φ",
+                                                                      &mut rng).or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -2712,9 +2753,9 @@ mod test {
                                            p2_their_encrypted_secret_shares[2].clone(),
                                            p3_their_encrypted_secret_shares[2].clone());
 
-            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
-            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (p1_group_key, _p1_secret_key) = p1_state.finish().or(Err(()))?;
             let (p2_group_key, _p2_secret_key) = p2_state.finish().or(Err(()))?;
@@ -2732,10 +2773,11 @@ mod test {
     fn keygen_static_2_out_of_3_with_common_participants() {
         fn do_test() -> Result<(), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng = OsRng;
 
-            let (dealer1, dealer1coeffs, dealer1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-            let (dealer2, dealer2coeffs, dealer2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-            let (dealer3, dealer3coeffs, dealer3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+            let (dealer1, dealer1coeffs, dealer1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (dealer2, dealer2coeffs, dealer2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (dealer3, dealer3coeffs, dealer3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             dealer1.proof_of_secret_key.as_ref().unwrap().verify(&dealer1.index, &dealer1.public_key().unwrap(), "Φ").or(Err(()))?;
             dealer2.proof_of_secret_key.as_ref().unwrap().verify(&dealer2.index, &dealer2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -2747,7 +2789,8 @@ mod test {
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (dealer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -2755,7 +2798,8 @@ mod test {
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (dealer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -2763,7 +2807,8 @@ mod test {
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer3_their_encrypted_secret_shares = dealer3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let dealer1_my_encrypted_secret_shares = vec!(dealer1_their_encrypted_secret_shares[0].clone(),
@@ -2776,9 +2821,9 @@ mod test {
                                                           dealer2_their_encrypted_secret_shares[2].clone(),
                                                           dealer3_their_encrypted_secret_shares[2].clone());
 
-            let dealer1_state = dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares).or(Err(()))?;
-            let dealer2_state = dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares).or(Err(()))?;
-            let dealer3_state = dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares).or(Err(()))?;
+            let dealer1_state = dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let dealer2_state = dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let dealer3_state = dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (dealer1_group_key, dealer1_secret_key) = dealer1_state.finish().or(Err(()))?;
             let (dealer2_group_key, dealer2_secret_key) = dealer2_state.finish().or(Err(()))?;
@@ -2787,38 +2832,41 @@ mod test {
             assert!(dealer1_group_key.0.compress() == dealer2_group_key.0.compress());
             assert!(dealer2_group_key.0.compress() == dealer3_group_key.0.compress());
 
-            let (signer1, signer1_dh_sk) = Participant::new_signer(&params, 1, "Φ");
-            let (signer2, signer2_dh_sk) = Participant::new_signer(&params, 2, "Φ");
+            let (signer1, signer1_dh_sk) = Participant::new_signer(&params, 1, "Φ", &mut rng);
+            let (signer2, signer2_dh_sk) = Participant::new_signer(&params, 2, "Φ", &mut rng);
             // Dealer 3 is also a participant of the next set of signers
             let (signer3, signer3_dh_sk) = (dealer3.clone(), dealer3_dh_sk);
 
             let signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone());
 
             let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer1_secret_key, &&signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params, dealer1_secret_key, &signers, "Φ", &mut rng).map_err(|_| ())?;
             let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer2_secret_key, &&signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params, dealer2_secret_key, &signers, "Φ", &mut rng).map_err(|_| ())?;
             let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer3_secret_key, &&signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params, dealer3_secret_key, &signers, "Φ", &mut rng).map_err(|_| ())?;
 
             let dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
             let (signer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let signer1_my_encrypted_secret_shares = vec!(dealer1_encrypted_shares_for_signers[0].clone(),
                                                           dealer2_encrypted_shares_for_signers[0].clone(),
@@ -2830,9 +2878,9 @@ mod test {
                                                           dealer2_encrypted_shares_for_signers[2].clone(),
                                                           dealer3_encrypted_shares_for_signers[2].clone());
 
-            let signer1_state = signer1_state.to_round_two(signer1_my_encrypted_secret_shares).or(Err(()))?;
-            let signer2_state = signer2_state.to_round_two(signer2_my_encrypted_secret_shares).or(Err(()))?;
-            let signer3_state = signer3_state.to_round_two(signer3_my_encrypted_secret_shares).or(Err(()))?;
+            let signer1_state = signer1_state.to_round_two(signer1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer2_state = signer2_state.to_round_two(signer2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer3_state = signer3_state.to_round_two(signer3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (signer1_group_key, _signer1_secret_key) = signer1_state.finish().or(Err(()))?;
             let (signer2_group_key, _signer2_secret_key) = signer2_state.finish().or(Err(()))?;
@@ -2852,10 +2900,11 @@ mod test {
     fn keygen_static_2_out_of_3_into_3_out_of_5() {
         fn do_test() -> Result<(), ()> {
             let params_dealers = Parameters { n: 3, t: 2 };
+            let mut rng = OsRng;
 
-            let (dealer1, dealer1coeffs, dealer1_dh_sk) = Participant::new_dealer(&params_dealers, 1, "Φ");
-            let (dealer2, dealer2coeffs, dealer2_dh_sk) = Participant::new_dealer(&params_dealers, 2, "Φ");
-            let (dealer3, dealer3coeffs, dealer3_dh_sk) = Participant::new_dealer(&params_dealers, 3, "Φ");
+            let (dealer1, dealer1coeffs, dealer1_dh_sk) = Participant::new_dealer(&params_dealers, 1, "Φ", &mut rng);
+            let (dealer2, dealer2coeffs, dealer2_dh_sk) = Participant::new_dealer(&params_dealers, 2, "Φ", &mut rng);
+            let (dealer3, dealer3coeffs, dealer3_dh_sk) = Participant::new_dealer(&params_dealers, 3, "Φ", &mut rng);
 
             dealer1.proof_of_secret_key.as_ref().unwrap().verify(&dealer1.index, &dealer1.public_key().unwrap(), "Φ").or(Err(()))?;
             dealer2.proof_of_secret_key.as_ref().unwrap().verify(&dealer2.index, &dealer2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -2867,7 +2916,8 @@ mod test {
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (dealer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
@@ -2875,7 +2925,8 @@ mod test {
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (dealer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
@@ -2883,7 +2934,8 @@ mod test {
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer3_their_encrypted_secret_shares = dealer3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let dealer1_my_encrypted_secret_shares = vec!(dealer1_their_encrypted_secret_shares[0].clone(),
@@ -2896,9 +2948,9 @@ mod test {
                                                           dealer2_their_encrypted_secret_shares[2].clone(),
                                                           dealer3_their_encrypted_secret_shares[2].clone());
 
-            let dealer1_state = dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares).or(Err(()))?;
-            let dealer2_state = dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares).or(Err(()))?;
-            let dealer3_state = dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares).or(Err(()))?;
+            let dealer1_state = dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let dealer2_state = dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let dealer3_state = dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (dealer1_group_key, dealer1_secret_key) = dealer1_state.finish().or(Err(()))?;
             let (dealer2_group_key, dealer2_secret_key) = dealer2_state.finish().or(Err(()))?;
@@ -2908,51 +2960,56 @@ mod test {
             assert!(dealer2_group_key.0.compress() == dealer3_group_key.0.compress());
 
             let params_signers = Parameters { n: 5, t: 3 };
-            let (signer1, signer1_dh_sk) = Participant::new_signer(&params_signers, 1, "Φ");
-            let (signer2, signer2_dh_sk) = Participant::new_signer(&params_signers, 2, "Φ");
-            let (signer3, signer3_dh_sk) = Participant::new_signer(&params_signers, 3, "Φ");
-            let (signer4, signer4_dh_sk) = Participant::new_signer(&params_signers, 4, "Φ");
-            let (signer5, signer5_dh_sk) = Participant::new_signer(&params_signers, 5, "Φ");
+            let (signer1, signer1_dh_sk) = Participant::new_signer(&params_signers, 1, "Φ", &mut rng);
+            let (signer2, signer2_dh_sk) = Participant::new_signer(&params_signers, 2, "Φ", &mut rng);
+            let (signer3, signer3_dh_sk) = Participant::new_signer(&params_signers, 3, "Φ", &mut rng);
+            let (signer4, signer4_dh_sk) = Participant::new_signer(&params_signers, 4, "Φ", &mut rng);
+            let (signer5, signer5_dh_sk) = Participant::new_signer(&params_signers, 5, "Φ", &mut rng);
 
             let signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone(), signer4.clone(), signer5.clone());
 
             let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer1_secret_key, &&signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params_signers, dealer1_secret_key, &signers, "Φ", &mut rng).map_err(|_| ())?;
             let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer2_secret_key, &&signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params_signers, dealer2_secret_key, &signers, "Φ", &mut rng).map_err(|_| ())?;
             let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer3_secret_key, &&signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params_signers, dealer3_secret_key, &signers, "Φ", &mut rng).map_err(|_| ())?;
 
             let dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
             let (signer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer4_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer4_dh_sk,
                                                                      &signer4.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer5_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer5_dh_sk,
                                                                      &signer5.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let signer1_my_encrypted_secret_shares = vec!(dealer1_encrypted_shares_for_signers[0].clone(),
                                                           dealer2_encrypted_shares_for_signers[0].clone(),
@@ -2970,11 +3027,11 @@ mod test {
                                                           dealer2_encrypted_shares_for_signers[4].clone(),
                                                           dealer3_encrypted_shares_for_signers[4].clone());
 
-            let signer1_state = signer1_state.to_round_two(signer1_my_encrypted_secret_shares).or(Err(()))?;
-            let signer2_state = signer2_state.to_round_two(signer2_my_encrypted_secret_shares).or(Err(()))?;
-            let signer3_state = signer3_state.to_round_two(signer3_my_encrypted_secret_shares).or(Err(()))?;
-            let signer4_state = signer4_state.to_round_two(signer4_my_encrypted_secret_shares).or(Err(()))?;
-            let signer5_state = signer5_state.to_round_two(signer5_my_encrypted_secret_shares).or(Err(()))?;
+            let signer1_state = signer1_state.to_round_two(signer1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer2_state = signer2_state.to_round_two(signer2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer3_state = signer3_state.to_round_two(signer3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer4_state = signer4_state.to_round_two(signer4_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer5_state = signer5_state.to_round_two(signer5_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (signer1_group_key, _signer1_secret_key) = signer1_state.finish().or(Err(()))?;
             let (signer2_group_key, _signer2_secret_key) = signer2_state.finish().or(Err(()))?;
@@ -3005,7 +3062,7 @@ mod test {
         let mut key = [0u8; 32];
         rng.fill(&mut key);
 
-        let encrypted_share = encrypt_share(&original_share, &key);
+        let encrypted_share = encrypt_share(&original_share, &key, &mut rng);
         let decrypted_share = decrypt_share(&encrypted_share, &key);
 
         assert!(decrypted_share.is_ok());
@@ -3016,10 +3073,11 @@ mod test {
     fn keygen_2_out_of_3_with_random_keys() {
         fn do_test() -> Result<(), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng: OsRng = OsRng;
 
-            let (p1, p1coeffs, dh_sk1) = Participant::new_dealer(&params, 1, "Φ");
-            let (p2, p2coeffs, dh_sk2) = Participant::new_dealer(&params, 2, "Φ");
-            let (p3, p3coeffs, dh_sk3) = Participant::new_dealer(&params, 3, "Φ");
+            let (p1, p1coeffs, dh_sk1) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (p2, p2coeffs, dh_sk2) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (p3, p3coeffs, dh_sk3) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").or(Err(()))?;
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -3031,7 +3089,8 @@ mod test {
                                                                      &p1.index,
                                                                      &p1coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -3039,7 +3098,8 @@ mod test {
                                                                      &p2.index,
                                                                      &p2coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -3047,7 +3107,8 @@ mod test {
                                                                       &p3.index,
                                                                       &p3coeffs,
                                                                       &participants,
-                                                                      "Φ").or(Err(()))?;
+                                                                      "Φ",
+                                                                      &mut rng).or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -3060,9 +3121,9 @@ mod test {
                                            p2_their_encrypted_secret_shares[2].clone(),
                                            p3_their_encrypted_secret_shares[2].clone());
 
-            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
-            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (p1_group_key, _p1_secret_key) = p1_state.finish().or(Err(()))?;
             let (p2_group_key, _p2_secret_key) = p2_state.finish().or(Err(()))?;
@@ -3080,10 +3141,11 @@ mod test {
     fn keygen_verify_complaint() {
         fn do_test() -> Result<(), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng: OsRng = OsRng;
 
-            let (p1, p1coeffs, dh_sk1) = Participant::new_dealer(&params, 1, "Φ");
-            let (p2, p2coeffs, dh_sk2) = Participant::new_dealer(&params, 2, "Φ");
-            let (p3, p3coeffs, dh_sk3) = Participant::new_dealer(&params, 3, "Φ");
+            let (p1, p1coeffs, dh_sk1) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (p2, p2coeffs, dh_sk2) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (p3, p3coeffs, dh_sk3) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").or(Err(()))?;
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -3095,7 +3157,8 @@ mod test {
                                                                      &p1.index,
                                                                      &p1coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -3103,7 +3166,8 @@ mod test {
                                                                      &p2.index,
                                                                      &p2coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -3111,7 +3175,8 @@ mod test {
                                                                       &p3.index,
                                                                       &p3coeffs,
                                                                       &participants,
-                                                                      "Φ").or(Err(()))?;
+                                                                      "Φ",
+                                                                      &mut rng).or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let mut complaint: Complaint;
@@ -3131,10 +3196,10 @@ mod test {
                                                p2_their_encrypted_secret_shares[2].clone(),
                                                p3_their_encrypted_secret_shares[2].clone());
 
-                let p1_state = p1_state.clone().to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+                let p1_state = p1_state.clone().to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
-                let complaints = p2_state.clone().to_round_two(p2_my_encrypted_secret_shares.clone());
+                let complaints = p2_state.clone().to_round_two(p2_my_encrypted_secret_shares.clone(), &mut rng);
                 assert!(complaints.is_err());
                 let complaints = complaints.unwrap_err();
                 if let Error::Complaint(complaints) = complaints {
@@ -3171,10 +3236,10 @@ mod test {
                                                p2_their_encrypted_secret_shares[2].clone(),
                                                p3_their_encrypted_secret_shares[2].clone());
 
-                let p1_state = p1_state.clone().to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+                let p1_state = p1_state.clone().to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
-                let complaints = p2_state.clone().to_round_two(p2_my_encrypted_secret_shares.clone());
+                let complaints = p2_state.clone().to_round_two(p2_my_encrypted_secret_shares.clone(), &mut rng);
                 assert!(complaints.is_err());
                 let complaints = complaints.unwrap_err();
                 if let Error::Complaint(complaints) = complaints {
@@ -3201,7 +3266,8 @@ mod test {
                         receiver_index: 2,
                         polynomial_evaluation: Scalar::from(42u32)
                     },
-                    &dh_key
+                    &dh_key,
+                    &mut rng,
                 );
                 let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
                                                p2_their_encrypted_secret_shares[0].clone(),
@@ -3214,10 +3280,10 @@ mod test {
                                                p2_their_encrypted_secret_shares[2].clone(),
                                                p3_their_encrypted_secret_shares[2].clone());
 
-                let p1_state = p1_state.clone().to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+                let p1_state = p1_state.clone().to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
-                let complaints = p2_state.clone().to_round_two(p2_my_encrypted_secret_shares.clone());
+                let complaints = p2_state.clone().to_round_two(p2_my_encrypted_secret_shares.clone(), &mut rng);
                 assert!(complaints.is_err());
                 let complaints = complaints.unwrap_err();
                 if let Error::Complaint(complaints) = complaints {
@@ -3247,7 +3313,7 @@ mod test {
                                                p2_their_encrypted_secret_shares[2].clone(),
                                                p3_their_encrypted_secret_shares[2].clone());
 
-                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
                 let bad_index = p3_state.blame(&p1_their_encrypted_secret_shares[0], &complaint);
                 assert!(bad_index == 2);
@@ -3262,10 +3328,11 @@ mod test {
     fn serialisation() {
         fn do_test() -> Result<(), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng: OsRng = OsRng;
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").or(Err(()))?;
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -3277,7 +3344,8 @@ mod test {
                                                                      &p1.index,
                                                                      &p1coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -3285,7 +3353,8 @@ mod test {
                                                                      &p2.index,
                                                                      &p2coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -3293,7 +3362,8 @@ mod test {
                                                                       &p3.index,
                                                                       &p3coeffs,
                                                                       &participants,
-                                                                      "Φ").or(Err(()))?;
+                                                                      "Φ",
+                                                                      &mut rng).or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             {
@@ -3333,9 +3403,9 @@ mod test {
 
                 // Continue KeyGen
 
-                let p1_state = p1_state.clone().to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-                let p2_state = p2_state.clone().to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
-                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+                let p1_state = p1_state.clone().to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+                let p2_state = p2_state.clone().to_round_two(p2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+                let p3_state = p3_state.clone().to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
                 let (p1_group_key, _p1_secret_key) = p1_state.clone().finish().or(Err(()))?;
                 let (p2_group_key, _p2_secret_key) = p2_state.finish().or(Err(()))?;
@@ -3368,10 +3438,10 @@ mod test {
                                            p2_their_encrypted_secret_shares[2].clone(),
                                            p3_their_encrypted_secret_shares[2].clone());
 
-                let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-                let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+                let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+                let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
-                let complaints = p2_state.to_round_two(p2_my_encrypted_secret_shares);
+                let complaints = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng);
                 assert!(complaints.is_err());
                 let complaints = complaints.unwrap_err();
                 if let Error::Complaint(complaints) = complaints {
@@ -3408,10 +3478,11 @@ mod test {
     fn individual_public_key_share() {
         fn do_test() -> Result<(), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng: OsRng = OsRng;
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").or(Err(()))?;
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -3423,7 +3494,8 @@ mod test {
                                                                      &p1.index,
                                                                      &p1coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -3431,7 +3503,8 @@ mod test {
                                                                      &p2.index,
                                                                      &p2coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -3439,7 +3512,8 @@ mod test {
                                                                       &p3.index,
                                                                       &p3coeffs,
                                                                       &participants,
-                                                                      "Φ").or(Err(()))?;
+                                                                      "Φ",
+                                                                      &mut rng).or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -3452,9 +3526,9 @@ mod test {
                                            p2_their_encrypted_secret_shares[2].clone(),
                                            p3_their_encrypted_secret_shares[2].clone());
 
-            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
-            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (p1_group_key, p1_secret_key) = p1_state.finish().or(Err(()))?;
             let (p2_group_key, p2_secret_key) = p2_state.finish().or(Err(()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,14 +59,17 @@
 //! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
+//! # use rand::rngs::OsRng;
 //! #
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! 
 //! // Each application developer should choose a context string as unique to their usage
-//! // as possible (instead of the below "Φ"), in order to prevent replay attacks.
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! // as possible (instead of the below "Φ"), in order to prevent replay attacks, as well as
+//! // a good cryptographic source of randomness.
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! ```
 //!
 //! They send these values to each of the other participants (also out of scope
@@ -92,13 +95,15 @@
 //! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! alice.proof_of_secret_key.as_ref().unwrap()
 //!     .verify(&alice.index, &alice.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -112,13 +117,15 @@
 //! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! bob.proof_of_secret_key.as_ref().unwrap()
 //!     .verify(&bob.index, &bob.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -132,13 +139,15 @@
 //! # use ice_frost::Participant;
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! carol.proof_of_secret_key.as_ref().unwrap()
 //!     .verify(&carol.index, &carol.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -155,13 +164,15 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), Error> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //!
 //! let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! let (alice_state, participant_lists) =
@@ -172,6 +183,7 @@
 //!         &alice_coefficients,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
@@ -185,18 +197,20 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //!
 //! // send_to_bob(alice_their_encrypted_secret_shares[0]);
 //! // send_to_carol(alice_their_encrypted_secret_shares[1]);
@@ -213,13 +227,15 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), Error> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! let (bob_state, participant_lists) =
@@ -230,20 +246,22 @@
 //!         &bob_coefficients,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )?;
 //! # Ok(()) }
 //! # fn do_test2() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
 //!
-//! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //!
 //! // send_to_alice(bob_their_encrypted_secret_shares[0]);
 //! // send_to_carol(bob_their_encrypted_secret_shares[1]);
@@ -260,13 +278,15 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), Error> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! let (carol_state, participant_lists) =
@@ -277,20 +297,22 @@
 //!         &carol_coefficients,
 //!         &participants,
 //!         "Φ",
+//!         &mut rng,
 //!     )?;
 //! # Ok(()) }
 //! # fn do_test2() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
 //!
-//! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //!
 //! // send_to_alice(carol_their_encrypted_secret_shares[0]);
 //! // send_to_bob(carol_their_encrypted_secret_shares[1]);
@@ -306,26 +328,28 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //!                                   bob_their_encrypted_secret_shares[0].clone(),
 //!                                   carol_their_encrypted_secret_shares[0].clone());
@@ -348,26 +372,28 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
@@ -378,9 +404,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -395,26 +421,28 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
@@ -425,9 +453,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! #
 //! let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
 //! let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
@@ -456,28 +484,30 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! 
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! 
 //! // Perform regular 2-out-of-3 DKG...
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
@@ -488,9 +518,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! 
 //! let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
 //! let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
@@ -502,21 +532,21 @@
 //! // Instantiate new configuration parameters and create a set of signers
 //! let new_params = Parameters { t: 3, n: 4 };
 //! 
-//! let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ");
-//! let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ");
-//! let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
-//! let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
+//! let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ", &mut rng);
+//! let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ", &mut rng);
+//! let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ", &mut rng);
+//! let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ", &mut rng);
 //! 
 //! let signers: Vec<Participant> =
 //!     vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
 //! let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
+//!     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! 
 //! let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
+//!     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! 
 //! let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//!     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
+//!     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -530,26 +560,28 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
@@ -560,9 +592,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
@@ -574,18 +606,18 @@
 //! # // Instantiate new configuration parameters and create a set of signers
 //! # let new_params = Parameters { t: 3, n: 4 };
 //! #
-//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ");
-//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ");
-//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
-//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
+//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ", &mut rng);
+//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ", &mut rng);
+//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ", &mut rng);
+//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ", &mut rng);
 //! #
 //! # let signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
 //! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! let dealers: Vec<Participant> =
 //!     vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
@@ -596,6 +628,7 @@
 //!         &alexis.index,
 //!         &dealers,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //! 
@@ -606,6 +639,7 @@
 //!         &barbara.index,
 //!         &dealers,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //! 
@@ -616,6 +650,7 @@
 //!         &claire.index,
 //!         &dealers,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //! 
@@ -626,6 +661,7 @@
 //!         &david.index,
 //!         &dealers,
 //!         "Φ",
+//!         &mut rng,
 //!     )
 //!     .or(Err(()))?;
 //! #
@@ -643,26 +679,28 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
@@ -673,9 +711,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
@@ -687,32 +725,32 @@
 //! # // Instantiate new configuration parameters and create a set of signers
 //! # let new_params = Parameters { t: 3, n: 4 };
 //! #
-//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ");
-//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ");
-//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
-//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
+//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ", &mut rng);
+//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ", &mut rng);
+//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ", &mut rng);
+//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ", &mut rng);
 //! #
 //! # let signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
 //! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let dealers: Vec<Participant> =
 //! #     vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
 //! # let (alexis_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &alexis_dh_sk, &alexis.index,
-//! #                                                    &dealers, "Φ").or(Err(()))?;
+//! #                                                    &dealers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let (barbara_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &barbara_dh_sk, &barbara.index,
-//! #                                                    &dealers, "Φ").or(Err(()))?;
+//! #                                                    &dealers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let (claire_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &claire_dh_sk, &claire.index,
-//! #                                                      &dealers, "Φ").or(Err(()))?;
+//! #                                                      &dealers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let (david_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &david_dh_sk, &david.index,
-//! #                                                      &dealers, "Φ").or(Err(()))?;
+//! #                                                      &dealers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let alexis_my_encrypted_secret_shares = vec!(alice_encrypted_shares[0].clone(),
 //! #                                   bob_encrypted_shares[0].clone(),
@@ -727,10 +765,10 @@
 //! #                                   bob_encrypted_shares[3].clone(),
 //! #                                   carol_encrypted_shares[3].clone());
 //! #
-//! let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares).or(Err(()))?;
-//! let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares).or(Err(()))?;
-//! let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares).or(Err(()))?;
-//! let david_state = david_state.to_round_two(david_my_encrypted_secret_shares).or(Err(()))?;
+//! let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! let david_state = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! # Ok(()) } fn main() { assert!(do_test().is_ok()); }
 //! ```
 //!
@@ -745,26 +783,28 @@
 //! # use curve25519_dalek::ristretto::RistrettoPoint;
 //! # use curve25519_dalek::traits::Identity;
 //! # use curve25519_dalek::scalar::Scalar;
+//! # use rand::rngs::OsRng;
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! # let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! # let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! # let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
@@ -775,9 +815,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
@@ -788,31 +828,31 @@
 //! #
 //! # let new_params = Parameters { t: 3, n: 4 };
 //! #
-//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ");
-//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ");
-//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ");
-//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ");
+//! # let (alexis, alexis_dh_sk) = Participant::new_signer(&new_params, 1, "Φ", &mut rng);
+//! # let (barbara, barbara_dh_sk) = Participant::new_signer(&new_params, 2, "Φ", &mut rng);
+//! # let (claire, claire_dh_sk) = Participant::new_signer(&new_params, 3, "Φ", &mut rng);
+//! # let (david, david_dh_sk) = Participant::new_signer(&new_params, 4, "Φ", &mut rng);
 //! #
 //! # let signers: Vec<Participant> = vec!(alexis.clone(), barbara.clone(), claire.clone(), david.clone());
 //! # let (alice_as_dealer, alice_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, alice_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! # let (bob_as_dealer, bob_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, bob_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! # let (carol_as_dealer, carol_encrypted_shares, participant_lists) =
-//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ").or(Err(()))?;
+//! #     Participant::reshare(&new_params, carol_secret_key, &signers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let dealers: Vec<Participant> = vec!(alice_as_dealer.clone(), bob_as_dealer.clone(), carol_as_dealer.clone());
 //! # let (alexis_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &alexis_dh_sk, &alexis.index,
-//! #                                                    &dealers, "Φ").or(Err(()))?;
+//! #                                                    &dealers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let (barbara_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &barbara_dh_sk, &barbara.index,
-//! #                                                    &dealers, "Φ").or(Err(()))?;
+//! #                                                    &dealers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let (claire_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &claire_dh_sk, &claire.index,
-//! #                                                      &dealers, "Φ").or(Err(()))?;
+//! #                                                      &dealers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let (david_state, participant_lists) = DistributedKeyGeneration::<_>::new(&params, &david_dh_sk, &david.index,
-//! #                                                      &dealers, "Φ").or(Err(()))?;
+//! #                                                      &dealers, "Φ", &mut rng).or(Err(()))?;
 //! #
 //! # let alexis_my_encrypted_secret_shares = vec!(alice_encrypted_shares[0].clone(),
 //! #                                   bob_encrypted_shares[0].clone(),
@@ -827,10 +867,10 @@
 //! #                                   bob_encrypted_shares[3].clone(),
 //! #                                   carol_encrypted_shares[3].clone());
 //! #
-//! # let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares).or(Err(()))?;
-//! # let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares).or(Err(()))?;
-//! # let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares).or(Err(()))?;
-//! # let david_state = david_state.to_round_two(david_my_encrypted_secret_shares).or(Err(()))?;
+//! # let alexis_state = alexis_state.to_round_two(alexis_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let barbara_state = barbara_state.to_round_two(barbara_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let claire_state = claire_state.to_round_two(claire_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let david_state = david_state.to_round_two(david_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! #
 //! let (alexis_group_key, alexis_secret_key) = alexis_state.finish().or(Err(()))?;
 //! let (barbara_group_key, barbara_secret_key) = barbara_state.finish().or(Err(()))?;
@@ -866,23 +906,24 @@
 //! use rand::rngs::OsRng;
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
@@ -893,9 +934,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
@@ -952,23 +993,24 @@
 //! #
 //! # fn do_test() -> Result<(), ()> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(()))?;
-//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares()?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(()))?;
-//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares()?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(()))?;
+//! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(()))?;;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
 //! #                                   carol_their_encrypted_secret_shares[0].clone());
@@ -979,9 +1021,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(()))?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(()))?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(()))?;
+//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(()))?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(()))?;
@@ -1031,22 +1073,23 @@
 //! #
 //! # fn do_test() -> Result<(), &'static str> {
 //! # let params = Parameters { t: 2, n: 3 };
+//! # let mut rng = OsRng;
 //! #
-//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+//! let (alice, alice_coefficients, alice_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+//! let (bob, bob_coefficients, bob_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+//! let (carol, carol_coefficients, carol_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 //! #
 //! # let participants: Vec<Participant> = vec!(alice.clone(), bob.clone(), carol.clone());
 //! # let (alice_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &alice_dh_sk, &alice.index, &alice_coefficients,
-//! #                                                      &participants, "Φ").or(Err(""))?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(""))?;
 //! # let alice_their_encrypted_secret_shares = alice_state.their_encrypted_secret_shares().or(Err(""))?;
 //! #
 //! # let (bob_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &bob_dh_sk, &bob.index, &bob_coefficients,
-//! #                                                    &participants, "Φ").or(Err(""))?;
+//! #                                                    &participants, "Φ", &mut rng).or(Err(""))?;
 //! # let bob_their_encrypted_secret_shares = bob_state.their_encrypted_secret_shares().or(Err(""))?;
 //! #
 //! # let (carol_state, participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params, &carol_dh_sk, &carol.index, &carol_coefficients,
-//! #                                                      &participants, "Φ").or(Err(""))?;
+//! #                                                      &participants, "Φ", &mut rng).or(Err(""))?;
 //! # let carol_their_encrypted_secret_shares = carol_state.their_encrypted_secret_shares().or(Err(""))?;
 //! # let alice_my_encrypted_secret_shares = vec!(alice_their_encrypted_secret_shares[0].clone(),
 //! #                                   bob_their_encrypted_secret_shares[0].clone(),
@@ -1058,9 +1101,9 @@
 //! #                                   bob_their_encrypted_secret_shares[2].clone(),
 //! #                                   carol_their_encrypted_secret_shares[2].clone());
 //! #
-//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares).or(Err(""))?;
-//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares).or(Err(""))?;
-//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares).or(Err(""))?;
+//! # let alice_state = alice_state.to_round_two(alice_my_encrypted_secret_shares, &mut rng).or(Err(""))?;
+//! # let bob_state = bob_state.to_round_two(bob_my_encrypted_secret_shares, &mut rng).or(Err(""))?;
+//! # let carol_state = carol_state.to_round_two(carol_my_encrypted_secret_shares, &mut rng).or(Err(""))?;
 //! #
 //! # let (alice_group_key, alice_secret_key) = alice_state.finish().or(Err(""))?;
 //! # let (bob_group_key, bob_secret_key) = bob_state.finish().or(Err(""))?;
@@ -1087,9 +1130,9 @@
 //! # let signers = aggregator.get_signers();
 //!
 //! let alice_partial = alice_secret_key.sign(&message_hash, &alice_group_key,
-//!                                           &mut alice_secret_comshares, 0, signers)?;
+//!                                           &mut alice_secret_comshares, 0, signers).or(Err(""))?;
 //! let carol_partial = carol_secret_key.sign(&message_hash, &carol_group_key,
-//!                                           &mut carol_secret_comshares, 0, signers)?;
+//!                                           &mut carol_secret_comshares, 0, signers).or(Err(""))?;
 //!
 //! aggregator.include_partial_signature(alice_partial);
 //! aggregator.include_partial_signature(carol_partial);

--- a/src/nizk.rs
+++ b/src/nizk.rs
@@ -72,7 +72,7 @@ impl NizkOfSecretKey {
     }
 
     /// Verify that the prover does indeed know the secret key.
-    pub fn verify(&self, index: &u32, public_key: &RistrettoPoint, context_string: &str) -> Result<(), ()> {
+    pub fn verify(&self, index: &u32, public_key: &RistrettoPoint, context_string: &str) -> Result<(), Error> {
         let M_prime: RistrettoPoint = (&RISTRETTO_BASEPOINT_TABLE * &self.r) + (public_key * -&self.s);
 
         let mut hram = Sha512::new();
@@ -88,7 +88,7 @@ impl NizkOfSecretKey {
             return Ok(());
         }
 
-        Err(())
+        Err(Error::InvalidProofOfKnowledge)
     }
 
     /// Serialise this proof to an array of bytes

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -743,8 +743,9 @@ mod test {
     #[test]
     fn signing_and_verification_single_party() {
         let params = Parameters { n: 1, t: 1 };
+        let mut rng = OsRng;
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
 
         p1.proof_of_secret_key.as_ref().unwrap().verify(&p1.index, &p1.public_key().unwrap(), "Φ").unwrap();
 
@@ -754,9 +755,10 @@ mod test {
                                                                  &p1.index,
                                                                  &p1coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
-        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
+        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).unwrap();
         let result = p1_state.finish();
 
         assert!(result.is_ok());
@@ -794,8 +796,9 @@ mod test {
     #[test]
     fn signing_and_verification_1_out_of_1() {
         let params = Parameters { n: 1, t: 1 };
+        let mut rng = OsRng;
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
 
         let participants: Vec<Participant> = vec![p1.clone()];
         let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -803,9 +806,10 @@ mod test {
                                                                  &p1.index,
                                                                  &p1coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p1_my_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap().clone();
-        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
+        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).unwrap();
 
         let (group_key, p1_sk) = p1_state.finish().unwrap();
 
@@ -834,9 +838,10 @@ mod test {
     #[test]
     fn signing_and_verification_1_out_of_2() {
         let params = Parameters { n: 2, t: 1 };
+        let mut rng = OsRng;
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
 
         let participants: Vec<Participant> = vec!(p1.clone(), p2.clone());
         let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -844,7 +849,8 @@ mod test {
                                                                  &p1.index,
                                                                  &p1coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
         let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -852,7 +858,8 @@ mod test {
                                                                  &p2.index,
                                                                  &p2coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
         let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -860,8 +867,8 @@ mod test {
         let p2_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[1].clone(),
                                                p2_their_encrypted_secret_shares[1].clone());
 
-        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
-        let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
+        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).unwrap();
 
         let (group_key, p1_sk) = p1_state.finish().unwrap();
         let (_, _p2_sk) = p2_state.finish().unwrap();
@@ -891,12 +898,13 @@ mod test {
     #[test]
     fn signing_and_verification_3_out_of_5() {
         let params = Parameters { n: 5, t: 3 };
+        let mut rng = OsRng;
 
-        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-        let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
-        let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ");
-        let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
+        let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+        let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+        let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
+        let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ", &mut rng);
+        let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ", &mut rng);
 
         let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
         let (p1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -904,7 +912,8 @@ mod test {
                                                                  &p1.index,
                                                                  &p1coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
         let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -912,7 +921,8 @@ mod test {
                                                                  &p2.index,
                                                                  &p2coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
         let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -920,7 +930,8 @@ mod test {
                                                                   &p3.index,
                                                                   &p3coeffs,
                                                                   &participants,
-                                                                  "Φ").unwrap();
+                                                                  "Φ",
+                                                                  &mut rng).unwrap();
         let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
         let (p4_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -928,7 +939,8 @@ mod test {
                                                                  &p4.index,
                                                                  &p4coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
         let (p5_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -936,7 +948,8 @@ mod test {
                                                                  &p5.index,
                                                                  &p5coeffs,
                                                                  &participants,
-                                                                 "Φ").unwrap();
+                                                                 "Φ",
+                                                                 &mut rng).unwrap();
         let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
         let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -969,11 +982,11 @@ mod test {
                                        p4_their_encrypted_secret_shares[4].clone(),
                                        p5_their_encrypted_secret_shares[4].clone());
 
-        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
-        let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
-        let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).unwrap();
-        let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
-        let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
+        let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares, &mut rng).unwrap();
+        let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares, &mut rng).unwrap();
 
         let (group_key, p1_sk) = p1_state.finish().unwrap();
         let (_, _) = p2_state.finish().unwrap();
@@ -1015,10 +1028,11 @@ mod test {
     fn signing_and_verification_2_out_of_3() {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng = OsRng;
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -1029,7 +1043,8 @@ mod test {
                                                                      &p1.index,
                                                                      &p1coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -1037,7 +1052,8 @@ mod test {
                                                                      &p2.index,
                                                                      &p2coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -1045,7 +1061,8 @@ mod test {
                                                                       &p3.index,
                                                                       &p3coeffs,
                                                                       &participants,
-                                                                      "Φ").or(Err(()))?;
+                                                                      "Φ",
+                                                                      &mut rng).or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -1058,9 +1075,9 @@ mod test {
                                            p2_their_encrypted_secret_shares[2].clone(),
                                            p3_their_encrypted_secret_shares[2].clone());
 
-            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
-            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (p1_group_key, p1_secret_key) = p1_state.finish().or(Err(()))?;
             let (p2_group_key, p2_secret_key) = p2_state.finish().or(Err(()))?;
@@ -1113,10 +1130,11 @@ mod test {
     fn signing_and_verification_static_2_out_of_3() {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng = OsRng;
 
-            let (dealer1, dealer1coeffs, dealer1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-            let (dealer2, dealer2coeffs, dealer2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-            let (dealer3, dealer3coeffs, dealer3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+            let (dealer1, dealer1coeffs, dealer1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (dealer2, dealer2coeffs, dealer2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (dealer3, dealer3coeffs, dealer3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             dealer1.proof_of_secret_key.as_ref().unwrap().verify(&dealer1.index, &dealer1.public_key().unwrap(), "Φ").or(Err(()))?;
             dealer2.proof_of_secret_key.as_ref().unwrap().verify(&dealer2.index, &dealer2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -1128,7 +1146,8 @@ mod test {
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (dealer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -1136,7 +1155,8 @@ mod test {
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (dealer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -1144,7 +1164,8 @@ mod test {
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer3_their_encrypted_secret_shares = dealer3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let dealer1_my_encrypted_secret_shares = vec!(dealer1_their_encrypted_secret_shares[0].clone(),
@@ -1157,9 +1178,9 @@ mod test {
                                                           dealer2_their_encrypted_secret_shares[2].clone(),
                                                           dealer3_their_encrypted_secret_shares[2].clone());
 
-            let dealer1_state = dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares).or(Err(()))?;
-            let dealer2_state = dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares).or(Err(()))?;
-            let dealer3_state = dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares).or(Err(()))?;
+            let dealer1_state = dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let dealer2_state = dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let dealer3_state = dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (dealer1_group_key, dealer1_secret_key) = dealer1_state.finish().or(Err(()))?;
             let (dealer2_group_key, dealer2_secret_key) = dealer2_state.finish().or(Err(()))?;
@@ -1168,37 +1189,40 @@ mod test {
             assert!(dealer1_group_key.0.compress() == dealer2_group_key.0.compress());
             assert!(dealer2_group_key.0.compress() == dealer3_group_key.0.compress());
 
-            let (signer1, signer1_dh_sk) = Participant::new_signer(&params, 1, "Φ");
-            let (signer2, signer2_dh_sk) = Participant::new_signer(&params, 2, "Φ");
-            let (signer3, signer3_dh_sk) = Participant::new_signer(&params, 3, "Φ");
+            let (signer1, signer1_dh_sk) = Participant::new_signer(&params, 1, "Φ", &mut rng);
+            let (signer2, signer2_dh_sk) = Participant::new_signer(&params, 2, "Φ", &mut rng);
+            let (signer3, signer3_dh_sk) = Participant::new_signer(&params, 3, "Φ", &mut rng);
 
             let signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone());
 
             let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer1_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params, dealer1_secret_key.clone(), &signers, "Φ", &mut rng).map_err(|_| ())?;
             let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer2_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params, dealer2_secret_key.clone(), &signers, "Φ", &mut rng).map_err(|_| ())?;
             let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params, dealer3_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params, dealer3_secret_key.clone(), &signers, "Φ", &mut rng).map_err(|_| ())?;
 
             let dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
             let (signer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let signer1_my_encrypted_secret_shares = vec!(dealer1_encrypted_shares_for_signers[0].clone(),
                                                           dealer2_encrypted_shares_for_signers[0].clone(),
@@ -1210,9 +1234,9 @@ mod test {
                                                           dealer2_encrypted_shares_for_signers[2].clone(),
                                                           dealer3_encrypted_shares_for_signers[2].clone());
 
-            let signer1_state = signer1_state.to_round_two(signer1_my_encrypted_secret_shares).or(Err(()))?;
-            let signer2_state = signer2_state.to_round_two(signer2_my_encrypted_secret_shares).or(Err(()))?;
-            let signer3_state = signer3_state.to_round_two(signer3_my_encrypted_secret_shares).or(Err(()))?;
+            let signer1_state = signer1_state.to_round_two(signer1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer2_state = signer2_state.to_round_two(signer2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer3_state = signer3_state.to_round_two(signer3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (signer1_group_key, signer1_secret_key) = signer1_state.finish().or(Err(()))?;
             let (signer2_group_key, signer2_secret_key) = signer2_state.finish().or(Err(()))?;
@@ -1323,10 +1347,11 @@ mod test {
                 ()>
         {
             let params_dealers = Parameters { n: 3, t: 2 };
+            let mut rng = OsRng;
 
-            let (dealer1, dealer1coeffs, dealer1_dh_sk) = Participant::new_dealer(&params_dealers, 1, "Φ");
-            let (dealer2, dealer2coeffs, dealer2_dh_sk) = Participant::new_dealer(&params_dealers, 2, "Φ");
-            let (dealer3, dealer3coeffs, dealer3_dh_sk) = Participant::new_dealer(&params_dealers, 3, "Φ");
+            let (dealer1, dealer1coeffs, dealer1_dh_sk) = Participant::new_dealer(&params_dealers, 1, "Φ", &mut rng);
+            let (dealer2, dealer2coeffs, dealer2_dh_sk) = Participant::new_dealer(&params_dealers, 2, "Φ", &mut rng);
+            let (dealer3, dealer3coeffs, dealer3_dh_sk) = Participant::new_dealer(&params_dealers, 3, "Φ", &mut rng);
 
             dealer1.proof_of_secret_key.as_ref().unwrap().verify(&dealer1.index, &dealer1.public_key().unwrap(), "Φ").or(Err(()))?;
             dealer2.proof_of_secret_key.as_ref().unwrap().verify(&dealer2.index, &dealer2.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -1338,7 +1363,8 @@ mod test {
                                                                      &dealer1.index,
                                                                      &dealer1coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer1_their_encrypted_secret_shares = dealer1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (dealer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
@@ -1346,7 +1372,8 @@ mod test {
                                                                      &dealer2.index,
                                                                      &dealer2coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer2_their_encrypted_secret_shares = dealer2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (dealer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params_dealers,
@@ -1354,7 +1381,8 @@ mod test {
                                                                      &dealer3.index,
                                                                      &dealer3coeffs,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let dealer3_their_encrypted_secret_shares = dealer3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let dealer1_my_encrypted_secret_shares = vec!(dealer1_their_encrypted_secret_shares[0].clone(),
@@ -1367,9 +1395,9 @@ mod test {
                                                           dealer2_their_encrypted_secret_shares[2].clone(),
                                                           dealer3_their_encrypted_secret_shares[2].clone());
 
-            let dealer1_state = dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares).or(Err(()))?;
-            let dealer2_state = dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares).or(Err(()))?;
-            let dealer3_state = dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares).or(Err(()))?;
+            let dealer1_state = dealer1_state.to_round_two(dealer1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let dealer2_state = dealer2_state.to_round_two(dealer2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let dealer3_state = dealer3_state.to_round_two(dealer3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (dealer1_group_key, dealer1_secret_key) = dealer1_state.finish().or(Err(()))?;
             let (dealer2_group_key, dealer2_secret_key) = dealer2_state.finish().or(Err(()))?;
@@ -1379,51 +1407,56 @@ mod test {
             assert!(dealer2_group_key.0.compress() == dealer3_group_key.0.compress());
 
             let params_signers = Parameters { n: 5, t: 3 };
-            let (signer1, signer1_dh_sk) = Participant::new_signer(&params_signers, 1, "Φ");
-            let (signer2, signer2_dh_sk) = Participant::new_signer(&params_signers, 2, "Φ");
-            let (signer3, signer3_dh_sk) = Participant::new_signer(&params_signers, 3, "Φ");
-            let (signer4, signer4_dh_sk) = Participant::new_signer(&params_signers, 4, "Φ");
-            let (signer5, signer5_dh_sk) = Participant::new_signer(&params_signers, 5, "Φ");
+            let (signer1, signer1_dh_sk) = Participant::new_signer(&params_signers, 1, "Φ", &mut rng);
+            let (signer2, signer2_dh_sk) = Participant::new_signer(&params_signers, 2, "Φ", &mut rng);
+            let (signer3, signer3_dh_sk) = Participant::new_signer(&params_signers, 3, "Φ", &mut rng);
+            let (signer4, signer4_dh_sk) = Participant::new_signer(&params_signers, 4, "Φ", &mut rng);
+            let (signer5, signer5_dh_sk) = Participant::new_signer(&params_signers, 5, "Φ", &mut rng);
 
             let signers: Vec<Participant> = vec!(signer1.clone(), signer2.clone(), signer3.clone(), signer4.clone(), signer5.clone());
 
             let (dealer1_for_signers, dealer1_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer1_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params_signers, dealer1_secret_key.clone(), &signers, "Φ", &mut rng).map_err(|_| ())?;
             let (dealer2_for_signers, dealer2_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer2_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params_signers, dealer2_secret_key.clone(), &signers, "Φ", &mut rng).map_err(|_| ())?;
             let (dealer3_for_signers, dealer3_encrypted_shares_for_signers, _participant_lists) =
-                Participant::reshare(&params_signers, dealer3_secret_key.clone(), &signers, "Φ").map_err(|_| ())?;
+                Participant::reshare(&params_signers, dealer3_secret_key.clone(), &signers, "Φ", &mut rng).map_err(|_| ())?;
 
             let dealers: Vec<Participant> = vec!(dealer1_for_signers, dealer2_for_signers, dealer3_for_signers);
             let (signer1_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer1_dh_sk,
                                                                      &signer1.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer2_dh_sk,
                                                                      &signer2.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer3_dh_sk,
                                                                      &signer3.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer4_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer4_dh_sk,
                                                                      &signer4.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let (signer5_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new(&params_dealers,
                                                                      &signer5_dh_sk,
                                                                      &signer5.index,
                                                                      &dealers,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
 
             let signer1_my_encrypted_secret_shares = vec!(dealer1_encrypted_shares_for_signers[0].clone(),
                                                           dealer2_encrypted_shares_for_signers[0].clone(),
@@ -1441,11 +1474,11 @@ mod test {
                                                           dealer2_encrypted_shares_for_signers[4].clone(),
                                                           dealer3_encrypted_shares_for_signers[4].clone());
 
-            let signer1_state = signer1_state.to_round_two(signer1_my_encrypted_secret_shares).or(Err(()))?;
-            let signer2_state = signer2_state.to_round_two(signer2_my_encrypted_secret_shares).or(Err(()))?;
-            let signer3_state = signer3_state.to_round_two(signer3_my_encrypted_secret_shares).or(Err(()))?;
-            let signer4_state = signer4_state.to_round_two(signer4_my_encrypted_secret_shares).or(Err(()))?;
-            let signer5_state = signer5_state.to_round_two(signer5_my_encrypted_secret_shares).or(Err(()))?;
+            let signer1_state = signer1_state.to_round_two(signer1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer2_state = signer2_state.to_round_two(signer2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer3_state = signer3_state.to_round_two(signer3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer4_state = signer4_state.to_round_two(signer4_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let signer5_state = signer5_state.to_round_two(signer5_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (signer1_group_key, signer1_secret_key) = signer1_state.finish().or(Err(()))?;
             let (signer2_group_key, signer2_secret_key) = signer2_state.finish().or(Err(()))?;
@@ -1573,10 +1606,11 @@ mod test {
     fn serialisation() {
         fn do_keygen() -> Result<(Parameters, SecretKey, SecretKey, SecretKey, GroupKey), ()> {
             let params = Parameters { n: 3, t: 2 };
+            let mut rng = OsRng;
 
-            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+            let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+            let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+            let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
             p2.proof_of_secret_key.as_ref().unwrap().verify(&p2.index, &p2.public_key().unwrap(), "Φ").or(Err(()))?;
             p3.proof_of_secret_key.as_ref().unwrap().verify(&p3.index, &p3.public_key().unwrap(), "Φ").or(Err(()))?;
@@ -1587,7 +1621,8 @@ mod test {
                                                                      &p1.index,
                                                                      &p1coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p2_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -1595,7 +1630,8 @@ mod test {
                                                                      &p2.index,
                                                                      &p2coeffs,
                                                                      &participants,
-                                                                     "Φ").or(Err(()))?;
+                                                                     "Φ",
+                                                                     &mut rng).or(Err(()))?;
             let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let (p3_state, _participant_lists) = DistributedKeyGeneration::<RoundOne>::new_initial(&params,
@@ -1603,7 +1639,8 @@ mod test {
                                                                       &p3.index,
                                                                       &p3coeffs,
                                                                       &participants,
-                                                                      "Φ").or(Err(()))?;
+                                                                      "Φ",
+                                                                      &mut rng).or(Err(()))?;
             let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().or(Err(()))?;
 
             let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -1616,9 +1653,9 @@ mod test {
                                            p2_their_encrypted_secret_shares[2].clone(),
                                            p3_their_encrypted_secret_shares[2].clone());
 
-            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).or(Err(()))?;
-            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).or(Err(()))?;
-            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).or(Err(()))?;
+            let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
+            let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).or(Err(()))?;
 
             let (p1_group_key, p1_secret_key) = p1_state.finish().or(Err(()))?;
             let (p2_group_key, p2_secret_key) = p2_state.finish().or(Err(()))?;

--- a/tests/frost.rs
+++ b/tests/frost.rs
@@ -27,12 +27,13 @@ use ice_frost::SignatureAggregator;
 #[test]
 fn signing_and_verification_3_out_of_5() {
     let params = Parameters { n: 5, t: 3 };
+    let mut rng = OsRng;
 
-    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
-    let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ");
-    let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ");
+    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
+    let (p4, p4coeffs, p4_dh_sk) = Participant::new_dealer(&params, 4, "Φ", &mut rng);
+    let (p5, p5coeffs, p5_dh_sk) = Participant::new_dealer(&params, 5, "Φ", &mut rng);
 
     let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone(), p4.clone(), p5.clone());
     let (p1_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
@@ -40,7 +41,8 @@ fn signing_and_verification_3_out_of_5() {
                                                              &p1.index,
                                                              &p1coeffs,
                                                              &participants,
-                                                             "Φ").unwrap();
+                                                             "Φ",
+                                                             &mut rng).unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
     let (p2_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
@@ -48,7 +50,8 @@ fn signing_and_verification_3_out_of_5() {
                                                              &p2.index,
                                                              &p2coeffs,
                                                              &participants,
-                                                             "Φ").unwrap();
+                                                             "Φ",
+                                                             &mut rng).unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
     let (p3_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
@@ -56,7 +59,8 @@ fn signing_and_verification_3_out_of_5() {
                                                              &p3.index,
                                                              &p3coeffs,
                                                              &participants,
-                                                             "Φ").unwrap();
+                                                             "Φ",
+                                                             &mut rng).unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
     let (p4_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
@@ -64,7 +68,8 @@ fn signing_and_verification_3_out_of_5() {
                                                              &p4.index,
                                                              &p4coeffs,
                                                              &participants,
-                                                             "Φ").unwrap();
+                                                             "Φ",
+                                                             &mut rng).unwrap();
     let p4_their_encrypted_secret_shares = p4_state.their_encrypted_secret_shares().unwrap();
 
     let (p5_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
@@ -72,7 +77,8 @@ fn signing_and_verification_3_out_of_5() {
                                                              &p5.index,
                                                              &p5coeffs,
                                                              &participants,
-                                                             "Φ").unwrap();
+                                                             "Φ",
+                                                             &mut rng).unwrap();
     let p5_their_encrypted_secret_shares = p5_state.their_encrypted_secret_shares().unwrap();
 
     let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -105,11 +111,11 @@ fn signing_and_verification_3_out_of_5() {
                                    p4_their_encrypted_secret_shares[4].clone(),
                                    p5_their_encrypted_secret_shares[4].clone());
 
-    let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
-    let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
-    let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).unwrap();
-    let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares).unwrap();
-    let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares).unwrap();
+    let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).unwrap();
+    let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).unwrap();
+    let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).unwrap();
+    let p4_state = p4_state.to_round_two(p4_my_encrypted_secret_shares, &mut rng).unwrap();
+    let p5_state = p5_state.to_round_two(p5_my_encrypted_secret_shares, &mut rng).unwrap();
 
     let (group_key, p1_sk) = p1_state.finish().unwrap();
     let (_, _) = p2_state.finish().unwrap();
@@ -151,10 +157,11 @@ fn signing_and_verification_3_out_of_5() {
 #[test]
 fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
     let params = Parameters { n: 3, t: 2 };
+    let mut rng = OsRng;
 
-    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ");
-    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ");
-    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ");
+    let (p1, p1coeffs, p1_dh_sk) = Participant::new_dealer(&params, 1, "Φ", &mut rng);
+    let (p2, p2coeffs, p2_dh_sk) = Participant::new_dealer(&params, 2, "Φ", &mut rng);
+    let (p3, p3coeffs, p3_dh_sk) = Participant::new_dealer(&params, 3, "Φ", &mut rng);
 
     let participants: Vec<Participant> = vec!(p1.clone(), p2.clone(), p3.clone());
     let (p1_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
@@ -162,7 +169,8 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
                                                       &p1.index,
                                                       &p1coeffs,
                                                       &participants,
-                                                      "Φ").unwrap();
+                                                      "Φ",
+                                                      &mut rng).unwrap();
     let p1_their_encrypted_secret_shares = p1_state.their_encrypted_secret_shares().unwrap();
 
     let (p2_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
@@ -170,7 +178,8 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
                                                      &p2.index,
                                                      &p2coeffs,
                                                      &participants,
-                                                     "Φ").unwrap();
+                                                     "Φ",
+                                                     &mut rng).unwrap();
     let p2_their_encrypted_secret_shares = p2_state.their_encrypted_secret_shares().unwrap();
 
     let (p3_state, _participant_lists) = DistributedKeyGeneration::<_>::new_initial(&params,
@@ -178,7 +187,8 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
                                                       &p3.index,
                                                       &p3coeffs,
                                                       &participants,
-                                                      "Φ").unwrap();
+                                                      "Φ",
+                                                      &mut rng).unwrap();
     let p3_their_encrypted_secret_shares = p3_state.their_encrypted_secret_shares().unwrap();
 
     let p1_my_encrypted_secret_shares = vec!(p1_their_encrypted_secret_shares[0].clone(),
@@ -193,9 +203,9 @@ fn signing_and_verification_with_ed25519_dalek_2_out_of_3() {
                                    p2_their_encrypted_secret_shares[2].clone(),
                                    p3_their_encrypted_secret_shares[2].clone());
 
-    let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares).unwrap();
-    let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares).unwrap();
-    let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares).unwrap();
+    let p1_state = p1_state.to_round_two(p1_my_encrypted_secret_shares, &mut rng).unwrap();
+    let p2_state = p2_state.to_round_two(p2_my_encrypted_secret_shares, &mut rng).unwrap();
+    let p3_state = p3_state.to_round_two(p3_my_encrypted_secret_shares, &mut rng).unwrap();
 
     let (group_key, p1_sk) = p1_state.finish().unwrap();
     let (_, p2_sk) = p2_state.finish().unwrap();


### PR DESCRIPTION
This PR includes:
- additional custom errors for the KeyGen phase
- a `SignatureError` enum for errors happening during the signing phase
- a relaxation of the randomness type, down to the usual `RngCore + CryptoRng`. It was previously using `OsRng` by default, now developers can specify the source of randomness they want to use. This is also a first step towards getting rid of `rand`/`rand_core` dependencies in favour of a Topos random crate.

closes #5
closes #13 