### PR TITLE
Fix flawky benchmark

### DIFF
--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -404,7 +404,7 @@ mod sign_benches {
         let message = b"This is a test of the tsunami alert system. This is only a test.";
 
         let mut participants_public_comshares = Vec::<PublicCommitmentShareList>::with_capacity(NUMBER_OF_PARTICIPANTS as usize);
-        let (p1_public_comshares, mut p1_secret_comshares) = generate_commitment_share_lists(&mut OsRng, 1, 1);
+        let (p1_public_comshares, p1_secret_comshares) = generate_commitment_share_lists(&mut OsRng, 1, 1);
         participants_public_comshares.push(p1_public_comshares);
 
         for i in 2..NUMBER_OF_PARTICIPANTS+1 {
@@ -422,7 +422,7 @@ mod sign_benches {
         let message_hash = compute_message_hash(&context[..], &message[..]);
 
         c.bench_function("Partial signature creation", move |b| {
-            b.iter(|| participants_secret_keys[0].sign(&message_hash, &group_key, &mut p1_secret_comshares, 0, signers));
+            b.iter(|| participants_secret_keys[0].sign(&message_hash, &group_key, &mut p1_secret_comshares.clone(), 0, signers));
         });
     }
 

--- a/src/precomputation.rs
+++ b/src/precomputation.rs
@@ -169,7 +169,7 @@ impl CommitmentShare {
 
 /// A secret commitment share list, containing the revealed nonces for the
 /// hiding and binding commitments.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SecretCommitmentShareList {
     /// The secret commitment shares.
     pub commitments: Vec<CommitmentShare>,


### PR DESCRIPTION
This PR makes sure the secret shares list is cloned before calling `sign()`, which would otherwise make all next iterations exit early because of length mismatch.