### PR TITLE
ci: add code coverage workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,39 @@
+name: Coverage
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  codecov:
+    name: Code coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: |
+          git config --global url."https://${{ secrets.ROBOT_TOPOSWARE_PRIV_REPOS_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: "--engine llvm --workspace --all-features --release"
+          timeout: 600
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions-rs/tarpaulin@v0.1
         with:
-          args: "--engine llvm --workspace --all-features --release"
+          args: "--engine llvm --workspace --release"
           timeout: 600
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Add a code coverage workflow that will create coverage report with tarpaulin and push the report to codecov for historical analysis.